### PR TITLE
Using separate yaml file for Target source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update documentation by [@chaimain](https://github.com/chaimain).
 - Remove dependency of hard-coded LAT files structure by [@chaimain](https://github.com/chaimain).
+- Using separate yaml file for Target source by [@chaimain](https://github.com/chaimain).
 
 ## [0.1](https://github.com/chaimain/asgardpy/releases/tag/v0.1) - 2023-02-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ When you're ready to contribute code to address an open issue, please follow the
 
     <details><summary>Expand details 👇</summary><br/>
 
-    Once you've added an "upstream" remote pointing to [https://github.com/allenai/python-package-temlate.git](https://github.com/chaimain/asgardpy), keeping your fork up-to-date is easy:
+    Once you've added an "upstream" remote pointing to [https://github.com/chaimain/asgardpy.git](https://github.com/chaimain/asgardpy), keeping your fork up-to-date is easy:
 
         git checkout main  # if not already on main
         git pull --rebase upstream main

--- a/asgardpy/analysis/analysis.py
+++ b/asgardpy/analysis/analysis.py
@@ -25,6 +25,11 @@ class AsgardpyAnalysis:
     the moment of instantiation. In that case these parameters will overwrite
     the default values of those present in the configuration file.
 
+    A specific example of an upgrade of the configuration parameters is when
+    the Target Models information is provided as a path to a separate yaml file,
+    which is readable with AsgardpyConfig. In this case, the configuration used
+    in AsgardpyAnalysis is updated in the initialization step itself.
+
     Parameters
     ----------
     config : dict or `AsgardpyConfig`
@@ -34,6 +39,11 @@ class AsgardpyAnalysis:
     def __init__(self, config):
         self.log = log
         self.config = config
+
+        if self.config.target.models_file.is_file():
+            other_config = AsgardpyConfig.read(self.config.target.models_file)
+            self.config = self.config.update(other_config)
+
         self.config.set_logging()
         self.datasets = Datasets()
         self.instrument_spectral_info = {"name": [], "spectral_energy_ranges": []}

--- a/asgardpy/config/model_template.yaml
+++ b/asgardpy/config/model_template.yaml
@@ -1,0 +1,40 @@
+components:
+-   name: ""
+    type: SkyModel
+    spectral:
+        type: LogParabolaSpectralModel
+        parameters:
+        -   name: amplitude
+            value: 1.0e-05
+            unit: cm-2 s-1 TeV-1
+            error: 1.5e-06
+            min: 1.0e-13
+            max: 0.01
+            frozen: false
+        -   name: reference
+            value: 0.0015
+            unit: TeV
+            error: 0.0
+            min: 0.0001
+            max: 100.0
+            frozen: true
+        -   name: alpha
+            value: 2
+            unit: ''
+            error: 0.1
+            min: 0.5
+            max: 5.0
+            frozen: false
+        -   name: beta
+            value: 0.1
+            unit: ''
+            error: 0.01
+            min: 0.01
+            max: 1.0
+            frozen: false
+        ebl_abs:
+          reference: dominguez
+          type: EBLAbsorptionNormSpectralModel
+          redshift: 0.4
+          alpha_norm: 1.0
+    covariance: None

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -20,48 +20,48 @@ target:
   sky_position: &source_pos {frame: icrs, lon: 238.92934976 deg, lat: 11.19010155 deg}
   use_uniform_position: true
   extended: false
+  models_file: "model_template.yaml"
   components:
-    name: PG1553+113
-    type: SkyModel
-    spectral:
-      model_name: LogParabola
-      type: LogParabolaSpectralModel # For Gammapy Model registry search
-      parameters:
-      -   name: amplitude
-          value: 1e-05
-          unit: cm-2 s-1 TeV-1
-          error: 1.5e-06
-          min: 1e-13
-          max: 0.01
-          frozen: false
-      -   name: reference
-          value: 0.0015
-          unit: TeV
-          error: 0.0
-          min: 0.0001
-          max: 100.0
-          frozen: true
-      -   name: alpha
-          value: 1.5
-          unit: ''
-          error: 0.1
-          min: 0.5
-          max: 5.0
-          frozen: false
-      -   name: beta
-          value: 0.1
-          unit: ''
-          error: 0.01
-          min: 1e-6
-          max: 1.0
-          frozen: false
-      ebl_abs:
-        model_name: dominguez
-        type: EBLAbsorptionNormSpectralModel # For Gammapy Model registry search
-        redshift: 0.433
-        alpha_norm: 1.0
+  -   name: PG1553+113
+      type: SkyModel
+      spectral:
+          type: LogParabolaSpectralModel # For Gammapy Model registry search
+          parameters:
+          -   name: amplitude
+              value: 1e-05
+              unit: cm-2 s-1 TeV-1
+              error: 1.5e-06
+              min: 1e-13
+              max: 0.01
+              frozen: false
+          -   name: reference
+              value: 0.0015
+              unit: TeV
+              error: 0.0
+              min: 0.0001
+              max: 100.0
+              frozen: true
+          -   name: alpha
+              value: 1.5
+              unit: ''
+              error: 0.1
+              min: 0.5
+              max: 5.0
+              frozen: false
+          -   name: beta
+              value: 0.1
+              unit: ''
+              error: 0.01
+              min: 1e-6
+              max: 1.0
+              frozen: false
+          ebl_abs:
+            reference: dominguez
+            type: EBLAbsorptionNormSpectralModel # For Gammapy Model registry search
+            redshift: 0.433
+            alpha_norm: 1.0
   covariance: None
-  from_fermi: false
+  from_3d: false
 
 # Instrument datasets with 3D info
 dataset3d:
@@ -105,7 +105,7 @@ dataset3d:
             min: 0.001 TeV
             max: 1 TeV
         on_region: *source_pos
-          # radius: 0.4 deg 
+          # radius: 0.4 deg
         containment_correction: true
         spectral_energy_range: &lat_energy_range
           min: 100 MeV

--- a/asgardpy/data/base.py
+++ b/asgardpy/data/base.py
@@ -75,7 +75,7 @@ class PathType(str):
             path_ = Path(v).resolve()
             # Only check if the file location or directory path exists
             if path_.is_file():
-                path_ = path_.parent()
+                path_ = path_.parent
 
             if path_.exists():
                 return Path(v)

--- a/asgardpy/data/dataset_1d.py
+++ b/asgardpy/data/dataset_1d.py
@@ -127,6 +127,7 @@ class Dataset1DGeneration:
     information provided on the 1D dataset and the target source.
 
     Runs the following steps:
+
     1. Read the DL3 files of 1D datasets into DataStore object.
 
     2. Perform any Observation selection, based on Observation IDs or time intervals.

--- a/asgardpy/data/dataset_1d.py
+++ b/asgardpy/data/dataset_1d.py
@@ -127,7 +127,6 @@ class Dataset1DGeneration:
     information provided on the 1D dataset and the target source.
 
     Runs the following steps:
-
     1. Read the DL3 files of 1D datasets into DataStore object.
 
     2. Perform any Observation selection, based on Observation IDs or time intervals.

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -223,12 +223,7 @@ class Dataset3DGeneration:
         """
         For each key type of files, read the files to get the required
         Gammapy objects for further analyses.
-
-        Model name is to check for scenario when an intrinsic LogParabola
-        model is saved as an EBL Attenuated Power Law model in LAT models.
         """
-        # lp_is_intrinsic = model.model_name == "LogParabola"
-
         file_list = {}
 
         for cfg in self.config_3d_dataset.io:

--- a/asgardpy/data/target.py
+++ b/asgardpy/data/target.py
@@ -125,7 +125,7 @@ def set_models(
         print(type(models))
         models = Models.read(models)
         print(type(models))
-    elif config.components:
+    elif len(config.components) > 0:
         spectral_model, spatial_model = read_models_from_asgardpy_config(config)
         models = Models(
             SkyModel(
@@ -175,7 +175,7 @@ def read_models_from_asgardpy_config(config):
     spatial_model: `gammapy.modeling.models.SpatialModel`
         Spatial Model components of a gammapy SkyModel object.
     """
-    model_config = config.components
+    model_config = config.components[0]
 
     # Spectral Model
     if model_config.spectral.ebl_abs.reference != "":
@@ -418,11 +418,7 @@ def create_source_skymodel(config_target, source, aux_path):
 
         # Only taking the spectral model information right now.
         if not config_target.from_3d:
-            if config_target.models_file.is_file():
-                models = Models.read(config_target.models_file)
-                spectral_model = models[0].spectral_model
-            else:
-                spectral_model, _ = read_models_from_asgardpy_config(config_target)
+            spectral_model, _ = read_models_from_asgardpy_config(config_target)
 
     if spectral_model is None:
         # Define the Spectral Model type for Gammapy

--- a/asgardpy/data/target.py
+++ b/asgardpy/data/target.py
@@ -114,17 +114,15 @@ def set_models(
         another model, maybe a Background Model. Not worked out currently.
 
     Returns
-    ------
+    -------
     datasets: `gammapy.datasets.Datasets`
         Datasets object with Models assigned.
     """
     # Have some checks on argument types
     if isinstance(models, DatasetModels) or isinstance(models, list):
         models = Models(models)
-    elif isinstance(models, PathType):  # Check this condition
-        print(type(models))
+    elif isinstance(models, PathType):
         models = Models.read(models)
-        print(type(models))
     elif len(config.components) > 0:
         spectral_model, spatial_model = read_models_from_asgardpy_config(config)
         models = Models(
@@ -163,8 +161,8 @@ def read_models_from_asgardpy_config(config):
     Reading Models information from AsgardpyConfig and return Spectral and
     Spatial Models object to be combined later into SkyModels/Models object.
 
-    Parameters
-    ----------
+    Parameter
+    ---------
     config: `AsgardpyConfig`
         Config section containing Target source information
 
@@ -217,8 +215,8 @@ def config_to_dict(model_config):
     model_config: `AsgardpyConfig`
         Config section containg Target Model SkyModel components only.
 
-    Return
-    ------
+    Returns
+    -------
     model_dict: dict
         dictionary of the particular model.
     """

--- a/asgardpy/io/io.py
+++ b/asgardpy/io/io.py
@@ -12,7 +12,7 @@ from gammapy.datasets import FluxPointsDataset
 from gammapy.estimators import FluxPoints
 from gammapy.modeling.models import Models
 
-from asgardpy.data.base import BaseConfig
+from asgardpy.data.base import BaseConfig, PathType
 
 __all__ = ["InputFilePatterns", "InputConfig", "DL3Files", "DL4Files"]
 
@@ -46,7 +46,7 @@ class InputFilePatterns(BaseConfig):
 
 class InputConfig(BaseConfig):
     type: str = "type"
-    input_dir: Path = Path(".")
+    input_dir: PathType = PathType(".")
     glob_pattern: dict = {}
 
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,7 +1,0 @@
-asgardpy.data module
-====================
-
-.. automodule:: asgardpy.data
-   :members: BaseConfig, AnalysisStep, Dataset1DGeneration, Datasets1DAnalysisStep, Dataset3DGeneration, Datasets3DAnalysisStep, FitAnalysisStep, FluxPointsAnalysisStep, LightCurveAnalysisStep
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/data_1d.rst
+++ b/docs/source/data_1d.rst
@@ -1,0 +1,7 @@
+asgardpy.data.dataset_1d module
+===============================
+
+.. automodule:: asgardpy.data.dataset_1d
+   :members: Dataset1DGeneration, Datasets1DAnalysisStep
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/data_3d.rst
+++ b/docs/source/data_3d.rst
@@ -1,0 +1,7 @@
+asgardpy.data.dataset_3d module
+===============================
+
+.. automodule:: asgardpy.data.dataset_3d
+   :members: Dataset3DGeneration, Datasets3DAnalysisStep
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/data_base.rst
+++ b/docs/source/data_base.rst
@@ -1,0 +1,7 @@
+asgardpy.data.base module
+=========================
+
+.. automodule:: asgardpy.data.base
+   :members: BaseConfig, AnalysisStep
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/data_dl4.rst
+++ b/docs/source/data_dl4.rst
@@ -1,0 +1,7 @@
+asgardpy.data.dl4 module
+========================
+
+.. automodule:: asgardpy.data.dl4
+   :members: FitAnalysisStep, FluxPointsAnalysisStep, LightCurveAnalysisStep
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/data_target.rst
+++ b/docs/source/data_target.rst
@@ -1,0 +1,7 @@
+asgardpy.data.target module
+===========================
+
+.. automodule:: asgardpy.data.target
+   :members: set_models, config_to_dict, create_source_skymodel, xml_to_gammapy_model_params, create_gal_diffuse_skymodel, create_iso_diffuse_skymodel
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,11 @@ Contents
    asgardpy
    analysis
    config
-   data
+   data_base
+   data_3d
+   data_1d
+   data_target
+   data_dl4
    io
 
 


### PR DESCRIPTION
As the `Models` selection for the dataset is independent of the DL3 files, one can use different `Models` for the `Target` source, by simply reading from separate config files (like `/asgardpy/config/model_template.yaml`), instead of updating the main `AsgardpyConfig` or duplicating it for the various combinations to be used by the user.

Also removed some unnecessary Config variables.