### PR TITLE
Generalize reading energy axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generalize usage of GeomConfig and Models for analysis with fermipy files by [@chaimain](https://github.com/chaimain).
 - Add support for common data types for different instruments by [@chaimain](https://github.com/chaimain).
 - Add support for selecting various spectral model parameters in a given Field of View by [@chaimain](https://github.com/chaimain).
+- Generalize reading energy axes by [@chaimain](https://github.com/chaimain).
 
 ## [0.1](https://github.com/chaimain/asgardpy/releases/tag/v0.1) - 2023-02-16
 

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -104,6 +104,7 @@ dataset3d:
                 min: "100 MeV"
                 max: "1 TeV"
                 nbins: 8
+                per_decade: true
           background:
           # method: reflected
           # parameters:
@@ -124,10 +125,16 @@ dataset3d:
         on_region: *source_pos
           # radius: 0.4 deg
         containment_correction: true
-        spectral_energy_range: &lat_energy_range
-          min: 100 MeV
-          max: 1 TeV
-          nbins: 4
+        spectral_energy_range:
+        -   name: energy
+            axis:
+              min: "100 MeV"
+              max: "1 TeV"
+              nbins: 4
+              per_decade: true
+            # axis_custom:
+            #   edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+            #   unit: "TeV"
 # - name: CTA
 #    ... full description ...
 
@@ -158,6 +165,7 @@ dataset1d:
                 min: "10 GeV"
                 max: "10 TeV"
                 nbins: 5
+                per_decade: true
           -   name: energy_true
               axis: *lst_energy
         observation:
@@ -175,7 +183,7 @@ dataset1d:
           methods: ["custom-mask"]
           parameters:
             min: "10 GeV"
-            max: "1 TeV"
+            max: "10 TeV"
             aeff_percent: 10
             bias_percent: 10
             fixed_offset: 0.1 deg
@@ -184,7 +192,16 @@ dataset1d:
         on_region: *source_pos
         containment_correction: false
         map_selection: [counts, exposure, edisp]
-        spectral_energy_range: *lst_energy
+        spectral_energy_range:
+        -   name: energy
+            axis:
+              min: "10 GeV"
+              max: "10 TeV"
+              nbins: 5
+              per_decade: true
+            # axis_custom:
+            #   edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+            #   unit: "TeV"
 #  - name: MAGIC
 #      ... full description ...
 

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -126,15 +126,15 @@ dataset3d:
           # radius: 0.4 deg
         containment_correction: true
         spectral_energy_range:
-        -   name: energy
-            axis:
-              min: "100 MeV"
-              max: "1 TeV"
-              nbins: 4
-              per_decade: true
-            # axis_custom:
-            #   edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
-            #   unit: "TeV"
+          name: energy
+          axis:
+            min: "100 MeV"
+            max: "1 TeV"
+            nbins: 4
+            per_decade: true
+        #  axis_custom:
+        #    edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+        #    unit: "TeV"
 # - name: CTA
 #    ... full description ...
 
@@ -193,15 +193,15 @@ dataset1d:
         containment_correction: false
         map_selection: [counts, exposure, edisp]
         spectral_energy_range:
-        -   name: energy
-            axis:
-              min: "10 GeV"
-              max: "10 TeV"
-              nbins: 5
-              per_decade: true
-            # axis_custom:
-            #   edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
-            #   unit: "TeV"
+          name: energy
+          axis:
+            min: "10 GeV"
+            max: "10 TeV"
+            nbins: 5
+            per_decade: true
+          #axis_custom:
+          #   edges: [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+          #   unit: "TeV"
 #  - name: MAGIC
 #      ... full description ...
 

--- a/asgardpy/data/__init__.py
+++ b/asgardpy/data/__init__.py
@@ -33,6 +33,7 @@ from asgardpy.data.geom import (
     SpatialCircleConfig,
     SpatialPointConfig,
     WcsConfig,
+    get_energy_axis,
 )
 from asgardpy.data.reduction import (
     BackgroundConfig,
@@ -101,6 +102,7 @@ __all__ = [
     "ProjectionEnum",
     "WcsConfig",
     "GeomConfig",
+    "get_energy_axis",
     "ReductionTypeEnum",
     "RequiredHDUEnum",
     "RegionsConfig",

--- a/asgardpy/data/dataset_1d.py
+++ b/asgardpy/data/dataset_1d.py
@@ -105,12 +105,10 @@ class Datasets1DAnalysisStep(AnalysisStepBase):
             # Get the spectral energy information for each Instrument Dataset
             energy_axes = config_1d_dataset.dataset_info.spectral_energy_range
             if len(energy_axes.axis_custom.edges) > 0:
-                energy_bin_edges = get_energy_axis(
-                    energy_axes.axis_custom, only_edges=True, custom_range=True
-                )
+                energy_bin_edges = get_energy_axis(energy_axes, only_edges=True, custom_range=True)
             else:
                 energy_bin_edges = get_energy_axis(
-                    energy_axes.axis,
+                    energy_axes,
                     only_edges=True,
                 )
             instrument_spectral_info["spectral_energy_ranges"].append(energy_bin_edges)

--- a/asgardpy/data/dataset_1d.py
+++ b/asgardpy/data/dataset_1d.py
@@ -21,11 +21,16 @@ from gammapy.makers import (
     SpectrumDatasetMaker,
     WobbleRegionsFinder,
 )
-from gammapy.maps import MapAxis, RegionGeom, WcsGeom
+from gammapy.maps import RegionGeom, WcsGeom
 from regions import CircleAnnulusSkyRegion, CircleSkyRegion, PointSkyRegion
 
 from asgardpy.data.base import AnalysisStepBase, BaseConfig
-from asgardpy.data.geom import EnergyAxisConfig, GeomConfig, SpatialPointConfig
+from asgardpy.data.geom import (
+    GeomConfig,
+    MapAxesConfig,
+    SpatialPointConfig,
+    get_energy_axis,
+)
 from asgardpy.data.reduction import (
     BackgroundConfig,
     MapSelectionEnum,
@@ -56,7 +61,7 @@ class Dataset1DInfoConfig(BaseConfig):
     on_region: SpatialPointConfig = SpatialPointConfig()
     containment_correction: bool = True
     map_selection: List[MapSelectionEnum] = []
-    spectral_energy_range: EnergyAxisConfig = EnergyAxisConfig()
+    spectral_energy_range: MapAxesConfig = MapAxesConfig()
 
 
 class Dataset1DBaseConfig(BaseConfig):
@@ -98,13 +103,16 @@ class Datasets1DAnalysisStep(AnalysisStepBase):
             dataset = generate_1d_dataset.run()
 
             # Get the spectral energy information for each Instrument Dataset
-            energy_range = config_1d_dataset.dataset_info.spectral_energy_range
-            energy_bin_edges = MapAxis.from_energy_bounds(
-                energy_min=u.Quantity(energy_range.min),
-                energy_max=u.Quantity(energy_range.max),
-                nbin=int(energy_range.nbins),
-                per_decade=True,
-            ).edges
+            energy_axes = config_1d_dataset.dataset_info.spectral_energy_range
+            if len(energy_axes.axis_custom.edges) > 0:
+                energy_bin_edges = get_energy_axis(
+                    energy_axes.axis_custom, only_edges=True, custom_range=True
+                )
+            else:
+                energy_bin_edges = get_energy_axis(
+                    energy_axes.axis,
+                    only_edges=True,
+                )
             instrument_spectral_info["spectral_energy_ranges"].append(energy_bin_edges)
 
             if self.config.general.stacked_dataset:
@@ -255,13 +263,7 @@ class Dataset1DGeneration:
         # Defining the energy axes
         axes_list = self.config_1d_dataset_info.geom.axes
         for axes_ in axes_list:
-            energy_axis = MapAxis.from_energy_bounds(
-                energy_min=u.Quantity(axes_.axis.min),
-                energy_max=u.Quantity(axes_.axis.max),
-                nbin=int(axes_.axis.nbins),
-                per_decade=True,
-                name=axes_.name,
-            )
+            energy_axis = get_energy_axis(axes_)
             # Main geom and template Spectrum Dataset
             if axes_.name == "energy":
                 geom = RegionGeom.create(region=on_region, axes=[energy_axis])

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -154,12 +154,10 @@ class Datasets3DAnalysisStep(AnalysisStepBase):
             # Get the spectral energy information for each Instrument Dataset
             energy_axes = config_3d_dataset.dataset_info.spectral_energy_range
             if len(energy_axes.axis_custom.edges) > 0:
-                energy_bin_edges = get_energy_axis(
-                    energy_axes.axis_custom, only_edges=True, custom_range=True
-                )
+                energy_bin_edges = get_energy_axis(energy_axes, only_edges=True, custom_range=True)
             else:
                 energy_bin_edges = get_energy_axis(
-                    energy_axes.axis,
+                    energy_axes,
                     only_edges=True,
                 )
 
@@ -463,7 +461,7 @@ class Dataset3DGeneration:
         """
         geom_config = self.config_3d_dataset.dataset_info.geom
 
-        energy_axes = geom_config.axes[0].axis
+        energy_axes = geom_config.axes[0]
         energy_axis = get_energy_axis(energy_axes)
         bin_size = geom_config.wcs.binsize.to_value(u.deg)
 

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -29,7 +29,12 @@ from gammapy.modeling.models import (
 from regions import CircleAnnulusSkyRegion, CircleSkyRegion
 
 from asgardpy.data.base import AnalysisStepBase, BaseConfig, TimeIntervalsConfig
-from asgardpy.data.geom import EnergyAxisConfig, GeomConfig, SpatialCircleConfig
+from asgardpy.data.geom import (
+    GeomConfig,
+    MapAxesConfig,
+    SpatialCircleConfig,
+    get_energy_axis,
+)
 from asgardpy.data.reduction import (
     BackgroundConfig,
     MapSelectionEnum,
@@ -66,7 +71,7 @@ class Dataset3DInfoConfig(BaseConfig):
     safe_mask: SafeMaskConfig = SafeMaskConfig()
     on_region: SpatialCircleConfig = SpatialCircleConfig()
     containment_correction: bool = True
-    spectral_energy_range: EnergyAxisConfig = EnergyAxisConfig()
+    spectral_energy_range: MapAxesConfig = MapAxesConfig()
 
 
 class Dataset3DBaseConfig(BaseConfig):
@@ -147,13 +152,16 @@ class Datasets3DAnalysisStep(AnalysisStepBase):
                     ].spectral_model.model2
 
             # Get the spectral energy information for each Instrument Dataset
-            energy_range = config_3d_dataset.dataset_info.spectral_energy_range
-            energy_bin_edges = MapAxis.from_energy_bounds(
-                energy_min=u.Quantity(energy_range.min),
-                energy_max=u.Quantity(energy_range.max),
-                nbin=int(energy_range.nbins),
-                per_decade=True,
-            ).edges
+            energy_axes = config_3d_dataset.dataset_info.spectral_energy_range
+            if len(energy_axes.axis_custom.edges) > 0:
+                energy_bin_edges = get_energy_axis(
+                    energy_axes.axis_custom, only_edges=True, custom_range=True
+                )
+            else:
+                energy_bin_edges = get_energy_axis(
+                    energy_axes.axis,
+                    only_edges=True,
+                )
 
             instrument_spectral_info["spectral_energy_ranges"].append(energy_bin_edges)
 
@@ -225,7 +233,7 @@ class Dataset3DGeneration:
         # Apply the same exclusion mask to the list of source models as applied
         # to the Counts Map
         self.list_sources = apply_selection_mask_to_models(
-            list_sources=self.list_sources,
+            self.list_sources,
             target_source=self.config_target.source_name,
             selection_mask=self.exclusion_mask,
         )
@@ -455,13 +463,8 @@ class Dataset3DGeneration:
         """
         geom_config = self.config_3d_dataset.dataset_info.geom
 
-        energy_range = geom_config.axes[0].axis
-        energy_axis = MapAxis.from_energy_bounds(
-            energy_min=u.Quantity(energy_range.min),
-            energy_max=u.Quantity(energy_range.max),
-            nbin=int(energy_range.nbins),
-            per_decade=True,
-        )
+        energy_axes = geom_config.axes[0].axis
+        energy_axis = get_energy_axis(energy_axes)
         bin_size = geom_config.wcs.binsize.to_value(u.deg)
 
         if geom_config.from_events_file:

--- a/asgardpy/data/geom.py
+++ b/asgardpy/data/geom.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import List
 
 from astropy import units as u
+from gammapy.maps import MapAxis
 
 from asgardpy.data.base import AngleType, BaseConfig, EnergyType, FrameEnum
 
@@ -21,6 +22,7 @@ __all__ = [
     "ProjectionEnum",
     "WcsConfig",
     "GeomConfig",
+    "get_energy_axis",
 ]
 
 
@@ -42,15 +44,18 @@ class EnergyAxisConfig(BaseConfig):
     min: EnergyType = 1 * u.GeV
     max: EnergyType = 1 * u.TeV
     nbins: int = 5
+    per_decade: bool = True
 
 
 class EnergyEdgesCustomConfig(BaseConfig):
-    edges: List[EnergyType] = []
+    edges: List[float] = []
+    unit: str = "TeV"
 
 
 class MapAxesConfig(BaseConfig):
     name: str = "energy"
     axis: EnergyAxisConfig = EnergyAxisConfig()
+    axis_custom: EnergyEdgesCustomConfig = EnergyEdgesCustomConfig()
 
 
 class SelectionConfig(BaseConfig):
@@ -86,3 +91,26 @@ class GeomConfig(BaseConfig):
     selection: SelectionConfig = SelectionConfig()
     axes: List[MapAxesConfig] = [MapAxesConfig()]
     from_events_file: bool = True
+
+
+def get_energy_axis(axes_config, only_edges=False, custom_range=False):
+    """
+    Read from a MapAxesConfig section to return the required energy axis/range.
+    """
+    energy_axis = axes_config.axis
+    energy_axis_custom = axes_config.axis_custom
+
+    if custom_range:
+        energy_range = energy_axis_custom.edges * u.Unit(energy_axis_custom.unit)
+    else:
+        energy_range = MapAxis.from_energy_bounds(
+            energy_min=u.Quantity(energy_axis.min),
+            energy_max=u.Quantity(energy_axis.max),
+            nbin=int(energy_axis.nbins),
+            per_decade=energy_axis.per_decade,
+            name=energy_axis.name,
+        )
+        if only_edges:
+            energy_range = energy_range.edges
+
+    return energy_range

--- a/asgardpy/data/geom.py
+++ b/asgardpy/data/geom.py
@@ -108,7 +108,7 @@ def get_energy_axis(axes_config, only_edges=False, custom_range=False):
             energy_max=u.Quantity(energy_axis.max),
             nbin=int(energy_axis.nbins),
             per_decade=energy_axis.per_decade,
-            name=energy_axis.name,
+            name=axes_config.name,
         )
         if only_edges:
             energy_range = energy_range.edges


### PR DESCRIPTION
Generalize reading of various energy axis and ranges to a single function in `asgardpy.data.geom.get_energy_axis`. Let the `spectral_energy_range` of each instrument dataset be of `asgardpy.data.geom.MapAxesConfig` type and also have the option of having either standard `gammapy.maps.MapAxis` energy bounds or custom energy ranges.