### PR TITLE
Remove GTI selections from 3D datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for selecting various spectral model parameters in a given Field of View by [@chaimain](https://github.com/chaimain).
 - Generalize reading energy axes by [@chaimain](https://github.com/chaimain).
 - Update notebooks by [@chaimain](https://github.com/chaimain).
+- Remove GTI selections from 3D datasets by [@chaimain](https://github.com/chaimain).
 
 ## [0.1](https://github.com/chaimain/asgardpy/releases/tag/v0.1) - 2023-02-16
 

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -89,7 +89,6 @@ dataset3d:
         name: Fermi-LAT
         key: ["FRONT", "BACK"]
         # map_selection: []
-        # obs_time:
         geom:
           from_events_file: True
           wcs:

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -12,7 +12,6 @@ import xmltodict
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.time import Time
 
 # from gammapy.analysis import Analysis, AnalysisConfig - no support for DL3 with RAD_MAX
 from gammapy.data import GTI, EventList
@@ -28,7 +27,7 @@ from gammapy.modeling.models import (
 )
 from regions import CircleAnnulusSkyRegion, CircleSkyRegion
 
-from asgardpy.data.base import AnalysisStepBase, BaseConfig, TimeIntervalsConfig
+from asgardpy.data.base import AnalysisStepBase, BaseConfig
 from asgardpy.data.geom import (
     GeomConfig,
     MapAxesConfig,
@@ -65,7 +64,6 @@ class Dataset3DInfoConfig(BaseConfig):
     name: str = "dataset-name"
     key: List = []
     map_selection: List[MapSelectionEnum] = MapDatasetMaker.available_selection
-    obs_time: TimeIntervalsConfig = TimeIntervalsConfig()
     geom: GeomConfig = GeomConfig()
     background: BackgroundConfig = BackgroundConfig()
     safe_mask: SafeMaskConfig = SafeMaskConfig()
@@ -414,23 +412,10 @@ class Dataset3DGeneration:
         """
         Loading the events files for the specific "Key" into an EventList
         object and the GTI information into a GTI object.
-
-        Based on any time intervals selection, filter out the events and gti
-        accordingly.
         """
         self.events["event_fits"] = fits.open(events_file)
         self.events["events"] = EventList.read(events_file)
         self.events["gti"] = GTI.read(events_file)
-
-        obs_time = self.config_3d_dataset.dataset_info.obs_time
-        if obs_time.intervals[0].start != Time("0", format="mjd"):
-            t_start = Time(obs_time.intervals[0].start, format=obs_time.format)
-            t_stop = Time(obs_time.intervals[0].stop, format=obs_time.format)
-            time_intervals = [t_start, t_stop]
-
-            self.events["events"] = self.events["events"].select_time(time_intervals)
-            self.events["gti"] = self.events["gti"].select_time(time_intervals)
-            self.log.info(f"Events selected in time intervals: {time_intervals}")
 
     def get_source_skycoord(self):
         """

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -174,8 +174,7 @@ class Dataset3DGeneration:
 
     Runs the following steps:
 
-    1. Read the DL3 files of 3D datasets into gammapy readable objects and perform any
-    selection of events in a given time interval.
+    1. Read the DL3 files of 3D datasets into gammapy readable objects.
 
     2. Create the base counts Map.
 

--- a/notebooks/SED_comparison_joint_fit_vs_individual_fit.ipynb
+++ b/notebooks/SED_comparison_joint_fit_vs_individual_fit.ipynb
@@ -149,59 +149,6 @@
    "source": []
   },
   {
-   "cell_type": "markdown",
-   "id": "d307748e",
-   "metadata": {},
-   "source": [
-    "## Update the Target parameters for only 1D analysis, in the config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "88e55051",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(only_1d_config.target.components.spectral.parameters[0])\n",
-    "only_1d_config.target.components.spectral.parameters[0].value = 1e-9\n",
-    "only_1d_config.target.components.spectral.parameters[0].error = 1e-10\n",
-    "print(only_1d_config.target.components.spectral.parameters[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "92c9ff5b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(only_1d_config.target.components.spectral.parameters[1])\n",
-    "only_1d_config.target.components.spectral.parameters[1].value = 0.07\n",
-    "print(only_1d_config.target.components.spectral.parameters[1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "43c876c9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(only_1d_config.target.components.spectral.parameters[2])\n",
-    "only_1d_config.target.components.spectral.parameters[2].value = 2.0\n",
-    "print(only_1d_config.target.components.spectral.parameters[2])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "33c33535",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "394d399a",
@@ -240,6 +187,101 @@
    "source": [
     "analysis"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d307748e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Update the Target parameters for only 1D analysis, in the config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88e55051",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(only_3d_analysis.config.target.components[0].spectral.parameters[0])\n",
+    "only_1d_analysis.config.target.components[0].spectral.parameters[0].value = 1e-9\n",
+    "only_1d_analysis.config.target.components[0].spectral.parameters[0].error = 1e-10\n",
+    "print(only_1d_analysis.config.target.components[0].spectral.parameters[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92c9ff5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(only_1d_analysis.config.target.components[0].spectral.parameters[1])\n",
+    "only_1d_analysis.config.target.components.spectral[0].parameters[1].value = 0.07\n",
+    "print(only_1d_analysis.config.target.components[0].spectral.parameters[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43c876c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(only_1d_analysis.config.target.components[0].spectral.parameters[2])\n",
+    "only_1d_analysis.config.target.components[0].spectral.parameters[2].value = 2.0\n",
+    "print(only_1d_analysis.config.target.components[0].spectral.parameters[2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33c33535",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebd542ae-7ca3-4b41-a315-89153fb555a1",
+   "metadata": {},
+   "source": [
+    "# Update Fit params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3123310-927d-4065-b1c9-36d7de6e5ed6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(only_3d_analysis.config.fit_params.fit_range.max)\n",
+    "only_3d_analysis.config.fit_params.fit_range.max = \"500 GeV\"\n",
+    "print(only_3d_analysis.config.fit_params.fit_range.max)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a49d5766-4071-45a8-8f59-c45dd4830910",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(only_1d_analysis.config.fit_params.fit_range.min)\n",
+    "only_1d_analysis.config.fit_params.fit_range.min = \"10 GeV\"\n",
+    "print(only_1d_analysis.config.fit_params.fit_range.min)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a0862bc-292e-401c-a3b7-0a8ccf651f66",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/notebooks/test_dataset_3d_step.ipynb
+++ b/notebooks/test_dataset_3d_step.ipynb
@@ -553,17 +553,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5222023a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Time interval to select events\n",
-    "print(generate_3d_dataset.config_3d_dataset.dataset_info.obs_time.intervals)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e37b21b2",
    "metadata": {},
    "outputs": [],

--- a/notebooks/test_dl4_steps.ipynb
+++ b/notebooks/test_dl4_steps.ipynb
@@ -330,17 +330,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8152d6f8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for i, en_range in enumerate(analysis.instrument_spectral_info[\"spectral_energy_ranges\"]):\n",
-    "    print(f\"The spectral energy range to be used for dataset {i+1} is {en_range}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "487a12e8",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
At least for Fermi-LAT datasets, one should not add any further GTI-based selections and only work with the provided set of files as they are produced for a select set of GTI time intervals amongst other selections and the various files produced, are exclusive for these selections.

GADF-based DL3 files for 1D Datasets can still have these GTI-based selections, but they must correspond to the 3D Dataset used.