### PR TITLE
Constrain pydantic and autodoc-pydantic versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add script to get most preferred spectral model fit by [@chaimain](https://github.com/chaimain).
 - Update documentation for the extended support by [@chaimain](https://github.com/chaimain).
 - Update with usage of common multiprocessing with Gammapy by [@chaimain](https://github.com/chaimain).
+- Constrain pydantic and autodoc-pydantic versions by [@chaimain](https://github.com/chaimain).
 
 ## [v0.3.3](https://github.com/chaimain/asgardpy/releases/tag/v0.3.3) - 2023-06-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ When you're ready to contribute code to address an open issue, please follow the
 
     Then you can create and activate a new Python environment by running:
 
-        conda create -n asgardpy python=3.9
+        conda create -n asgardpy python=3.10
         conda activate asgardpy
 
     Once your virtual environment is activated, you can install your local clone in "editable mode" with

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -39,7 +39,7 @@ sphinx-autobuild>=2021.3.14
 sphinx-autodoc-typehints
 
 # For documenting pydantic modules, classes and fields
-autodoc_pydantic
+autodoc_pydantic<2
 
 # For parsing and comparing version numbers.
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ seaborn
 iminuit>=2.8.0
 ruamel.yaml
 xmltodict
-pydantic
+pydantic<2


### PR DESCRIPTION
<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Partially Fixes #91 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
-Until `autodoc-pydantic` and `Gammapy` do not support the new `pydantic v2`, constrain the versions here
