### PR TITLE
Restructure pipeline for better handling of model association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update docs with Zenodo DOI by [@chaimain](https://github.com/chaimain).
 - Restructure pipeline to regroup common functions for GADF-based DL3 files for 1D and 3D dataset by [@chaimain](https://github.com/chaimain).
 - Update documentation and notebooks for the restructured pipeline by [@chaimain](https://github.com/chaimain).
+- Restructure pipeline for better handling of model association by [@chaimain](https://github.com/chaimain).
 
 ## [v0.3.4](https://github.com/chaimain/asgardpy/releases/tag/v0.3.4) - 2023-07-02
 

--- a/asgardpy/analysis/analysis.py
+++ b/asgardpy/analysis/analysis.py
@@ -68,8 +68,6 @@ class AsgardpyAnalysis:
             self.datasets,
             self.dataset_name_list,
             models=model,
-            target_source_name=self.config.target.source_name,
-            add_fov_bkg_model=False,
         )
 
     @property

--- a/asgardpy/analysis/analysis.py
+++ b/asgardpy/analysis/analysis.py
@@ -56,7 +56,7 @@ class AsgardpyAnalysis:
             setattr(self, data_product, None)
 
     @property
-    def models(self):  # Check if it really worked. If not, then just have a ._models
+    def models(self):
         if not self.datasets:
             raise RuntimeError("No datasets defined. Impossible to set models.")
         return self.datasets.models
@@ -104,9 +104,6 @@ class AsgardpyAnalysis:
                         # If the target source has Spatial model included,
                         # only then (?) get all the models as final_model.
                         # Needs reconsideration.
-
-                        # Also, what if there are more than 1 type of 3D
-                        # datasets with each their own list of associated models ??
                         for m in models_list:
                             self.final_model.append(m)
                     else:

--- a/asgardpy/analysis/analysis.py
+++ b/asgardpy/analysis/analysis.py
@@ -61,15 +61,6 @@ class AsgardpyAnalysis:
             raise RuntimeError("No datasets defined. Impossible to set models.")
         return self.datasets.models
 
-    @models.setter
-    def models(self, model):
-        self.datasets = set_models(
-            self.config.target,
-            self.datasets,
-            self.dataset_name_list,
-            models=model,
-        )
-
     @property
     def config(self):
         """
@@ -137,7 +128,12 @@ class AsgardpyAnalysis:
                 for edges in instrument_spectral_info["spectral_energy_ranges"]:
                     self.instrument_spectral_info["spectral_energy_ranges"].append(edges)
 
-        self.models(self.final_model)
+        self.datasets, self.final_model = set_models(
+            self.config.target,
+            self.datasets,
+            self.dataset_name_list,
+            models=self.final_model,
+        )
 
         if len(dl4_dl5_steps) > 0:
             self.log.info("Perform DL4 to DL5 processes!")

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -22,6 +22,7 @@ target:
   use_uniform_position: true
   add_fov_bkg_model: false
   #models_file: "template_model.yaml"
+  #use_catalog: "3fgl"
   components:
   -   name: PG1553+113
       type: SkyModel

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -22,7 +22,10 @@ target:
   use_uniform_position: true
   add_fov_bkg_model: false
   #models_file: "template_model.yaml"
-  #use_catalog: "3fgl"
+  #use_catalog:
+    #name: "3fgl"
+    #selection_radius: 0.4 deg
+    #exclusion_radius: 0.5 deg
   components:
   -   name: PG1553+113
       type: SkyModel

--- a/asgardpy/config/template.yaml
+++ b/asgardpy/config/template.yaml
@@ -20,7 +20,7 @@ target:
   source_name: PG1553+113
   sky_position: &source_pos {frame: icrs, lon: 238.92934976 deg, lat: 11.19010155 deg, radius: 0 deg}
   use_uniform_position: true
-  extended: false
+  add_fov_bkg_model: false
   #models_file: "template_model.yaml"
   components:
   -   name: PG1553+113

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -135,13 +135,10 @@ class Datasets3DAnalysisStep(AnalysisStepBase):
 
                 # What if there are no associated models?
                 for model_ in models:
-                    if key:
-                        model_.datasets_names = [f"{config_3d_dataset.name}_{key}"]
-                    else:
-                        model_.datasets_names = [f"{config_3d_dataset.name}"]
+                    model_.datasets_names = [dataset.name]
 
-                    if model_.name in models_final.names:
-                        models_final[model_.name].datasets_names.append(model_.datasets_names[0])
+                    if model_.name in models_final.names:  # Should it not be "not in "??
+                        models_final[model_.name].datasets_names.append(dataset.name)
                     else:
                         models_final.append(model_)
 

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -280,7 +280,8 @@ class Dataset3DGeneration:
                     inside_geom = base_geom.to_image().contains(catalog.positions)
 
                     idx_list = np.nonzero(inside_geom)[0]
-                    self.list_sources.append([catalog[i].sky_model() for i in idx_list])
+                    for i in idx_list:
+                        self.list_sources.append(catalog[i].sky_model())
 
             exclusion_mask = get_exclusion_region_mask(
                 exclusion_params=self.config_3d_dataset.dataset_info.background.exclusion,

--- a/asgardpy/data/dataset_3d.py
+++ b/asgardpy/data/dataset_3d.py
@@ -133,28 +133,33 @@ class Datasets3DAnalysisStep(AnalysisStepBase):
                 # Assigning datasets_names and including them in the final
                 # model list
 
-                # What if there are no associated models?
-                for model_ in models:
-                    model_.datasets_names = [dataset.name]
+                # When no associated list of models are provided, look for a
+                # separate model for target and an entry of catalog to fill in.
+                if len(models) > 0:
+                    for model_ in models:
+                        model_.datasets_names = [dataset.name]
 
-                    if model_.name in models_final.names:  # Should it not be "not in "??
-                        models_final[model_.name].datasets_names.append(dataset.name)
-                    else:
-                        models_final.append(model_)
+                        if model_.name in models_final.names:
+                            models_final[model_.name].datasets_names.append(dataset.name)
+                        else:
+                            models_final.append(model_)
 
                 dataset_instrument.append(dataset)
 
-            # Linking the spectral model of the diffuse model for each key
-            diffuse_models_names = []
-            for model_name in models_final.names:
-                if "diffuse-iso" in model_name:
-                    diffuse_models_names.append(model_name)
+            if len(models_final) > 0:
+                # Linking the spectral model of the diffuse model for each key
+                diffuse_models_names = []
+                for model_name in models_final.names:
+                    if "diffuse-iso" in model_name:
+                        diffuse_models_names.append(model_name)
 
-            if len(diffuse_models_names) > 1:
-                for model_name in diffuse_models_names[1:]:
-                    models_final[diffuse_models_names[0]].spectral_model.model2 = models_final[
-                        model_name
-                    ].spectral_model.model2
+                if len(diffuse_models_names) > 1:
+                    for model_name in diffuse_models_names[1:]:
+                        models_final[diffuse_models_names[0]].spectral_model.model2 = models_final[
+                            model_name
+                        ].spectral_model.model2
+            else:
+                models_final = None
 
             # Get the spectral energy information for each Instrument Dataset
             energy_axes = config_3d_dataset.dataset_info.spectral_energy_range

--- a/asgardpy/data/target.py
+++ b/asgardpy/data/target.py
@@ -222,8 +222,6 @@ def set_models(
     datasets,
     datasets_name_list=None,
     models=None,
-    target_source_name=None,
-    add_fov_bkg_model=False,
 ):
     """
     Set models on given Datasets.
@@ -239,12 +237,6 @@ def set_models(
         to the given datasets.
     models : `~gammapy.modeling.models.Models` or str
         Models object or YAML models string
-    target_source_name: str
-        Name of the Target source, to use to update only that Model's
-        datasets_names, when a list of more than 1 models are provided.
-    add_fov_bkg_model : bool
-        Add a FoVBackgroundModel for 3D Datasets. Maybe this needs another
-        config option from the user.
 
     Returns
     -------
@@ -279,7 +271,7 @@ def set_models(
             free_sources=config.target.roi_selection.free_sources,
         )
 
-    if add_fov_bkg_model:
+    if config.target.add_fov_bkg_model:
         # For extending a Background Model for each 3D dataset
         bkg_models = []
 
@@ -292,11 +284,8 @@ def set_models(
     if datasets_name_list is None:
         datasets_name_list = datasets.names
 
-    if target_source_name is None:
-        target_source_name = config.source_name
-
     if len(models) > 1:
-        models[target_source_name].datasets_names = datasets_name_list
+        models[config.target.source_name].datasets_names = datasets_name_list
     else:
         models.datasets_names = datasets_name_list
 

--- a/asgardpy/data/target.py
+++ b/asgardpy/data/target.py
@@ -8,6 +8,7 @@ from typing import List
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
+from gammapy.catalog import CATALOG_REGISTRY
 from gammapy.maps import Map
 from gammapy.modeling import Parameter, Parameters
 from gammapy.modeling.models import (
@@ -97,6 +98,7 @@ class Target(BaseConfig):
     use_uniform_position: bool = True
     models_file: PathType = PathType(".")
     add_fov_bkg_model: bool = False
+    use_catalog: str = ""
     components: List[SkyModelComponent] = [SkyModelComponent()]
     covariance: str = ""
     from_3d: bool = False
@@ -261,6 +263,19 @@ def set_models(
                     name=config_target.source_name,
                 )
             )
+            # If there is no explicit list of models provided for the 3D data,
+            # one can use one of the several catalogs available in Gammapy.
+            # Reading them as Models will keep the procedure uniform.
+
+            # Note, in this case the target config should have spatial model
+            # in the above step!
+
+            if config_target.use_catalog != "":
+                catalog_models = CATALOG_REGISTRY.get_cls(config_target.use_catalog)().to_models()
+                # One can also provide a separate file, but one has to add
+                # another config option for reading Catalog file paths.
+                models.extend(catalog_models)
+
         else:
             raise Exception("No input for Models provided!")
     else:

--- a/docs/source/_templates/template.yaml
+++ b/docs/source/_templates/template.yaml
@@ -22,6 +22,7 @@ target:
   use_uniform_position: true
   add_fov_bkg_model: false
   #models_file: "template_model.yaml"
+  #use_catalog: "3fgl"
   components:
   -   name: PG1553+113
       type: SkyModel

--- a/docs/source/_templates/template.yaml
+++ b/docs/source/_templates/template.yaml
@@ -22,7 +22,10 @@ target:
   use_uniform_position: true
   add_fov_bkg_model: false
   #models_file: "template_model.yaml"
-  #use_catalog: "3fgl"
+  #use_catalog:
+    #name: "3fgl"
+    #selection_radius: 0.4 deg
+    #exclusion_radius: 0.5 deg
   components:
   -   name: PG1553+113
       type: SkyModel

--- a/docs/source/_templates/template.yaml
+++ b/docs/source/_templates/template.yaml
@@ -20,7 +20,7 @@ target:
   source_name: PG1553+113
   sky_position: &source_pos {frame: icrs, lon: 238.92934976 deg, lat: 11.19010155 deg, radius: 0 deg}
   use_uniform_position: true
-  extended: false
+  add_fov_bkg_model: false
   #models_file: "template_model.yaml"
   components:
   -   name: PG1553+113

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -25,9 +25,14 @@ The steps are:
 
 #. flux-points :class:`asgardpy.data.dl4.FluxPointsAnalysisStep`
 
-The main purpose of this pipeline is accomplished before the "fit" step, which is to compile a Gammapy Datasets object
-containing multiple types of datasets from multiple gamma-ray astronomical instruments, update them with appropriate
-Gammapy Models object. These are then run with the standard Gammapy high-level analysis functions to get the DL5 products.
+The main purpose of this pipeline is accomplished for -
+
+#. performing DL3 to DL4 for a joint dataset - to compile a joint Gammapy Datasets (DL4) object
+containing multiple types of datasets from DL3 files of multiple gamma-ray astronomical instruments
+
+#. update the joint DL4 data with appropriate Gammapy Models object.
+
+#. perform DL4 to DL5 (SED only) after performing joint-likelihood fitting.
 
 
 .. image:: ./_static/asgardpy_workflow.png
@@ -71,6 +76,36 @@ Models
 ------
 
 The :doc:`_api_docs/data_target_b` contains various classes for various Models objects and :doc:`_api_docs/data_target_f` contains various functions for handling them.
+
+
+The information regarding the model to be used for the target source is given by :class:`asgardpy.data.target.Target` and the various input options are -
+
+#. Include the model information in :func:`AsgardpyConfig.target.components`
+
+#. Include the path for a separate model file in :attr:`AsgardpyConfig.target.models_file`
+
+#. Use :attr:`AsgardpyConfig.target.from_3d` = True, if the model is included in the list of Models provided with the 3D Dataset
+
+
+The list of associated Models can be provided by -
+
+#. Using a file provided along with the DL3 data of the 3D data (XML type for Fermi-LAT)
+
+#. Using a Catalog available in Gammapy, by adding information in :attr:`AsgardpyConfig.target.use_catalog`
+
+
+While combining DL4 datasets from multiple instruments, the positions of the target source, included within these data, may not be exactly the same.
+This will cause computation issue for the binned analysis performed with Gammapy. To resolve this issue, use :attr:`AsgardpyConfig.target.use_uniform_position` = True.
+
+
+To add a Gammapy `FoVBackgroundModel` to the 3D dataset, use :attr:`AsgardpyConfig.target.add_fov_bkg_model` = True
+
+
+The :py:func:`asgardpy.data.target.apply_selection_mask_to_models` function is used to apply various selections on the given list of models.
+
+
+To perform some tests on the preference of the assumed spectral model of the target source, use either :func:`asgardpy.data.target.check_model_preference_lrt` or :func:`asgardpy.data.target.check_model_preference_aic`.
+
 
 High-level Analysis
 -------------------

--- a/notebooks/test_dl4_steps.ipynb
+++ b/notebooks/test_dl4_steps.ipynb
@@ -302,7 +302,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a5aca26f",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(analysis.final_model)"
@@ -312,7 +314,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a962a9bf",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for m in analysis.final_model:\n",
@@ -372,7 +376,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dfea2d18",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(analysis.datasets)"
@@ -395,7 +401,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cf6652a5",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for m in analysis.final_model:\n",
@@ -488,7 +496,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98063d01",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for model_ in analysis.final_model:\n",
@@ -518,32 +528,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis.datasets = set_models(\n",
+    "analysis.datasets, analysis.final_model = set_models(\n",
     "    analysis.config.target,\n",
     "    analysis.datasets,\n",
     "    analysis.dataset_name_list,\n",
     "    models=analysis.final_model,\n",
-    "    target_source_name=analysis.config.target.source_name,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa164c3e",
+   "id": "d25dedaf",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
-   "source": [
-    "print(analysis.datasets)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d25dedaf",
-   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -600,7 +599,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3d28d06f",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for m in analysis.datasets[0].models:\n",

--- a/notebooks/test_models.ipynb
+++ b/notebooks/test_models.ipynb
@@ -10,6 +10,7 @@
     "from asgardpy.analysis import AsgardpyAnalysis\n",
     "from asgardpy.config import AsgardpyConfig\n",
     "\n",
+    "from gammapy.catalog import CATALOG_REGISTRY\n",
     "from gammapy.modeling.models import Models, SPECTRAL_MODEL_REGISTRY, SPATIAL_MODEL_REGISTRY\n",
     "from gammapy.maps import Map\n",
     "\n",
@@ -29,6 +30,7 @@
    "outputs": [],
    "source": [
     "from asgardpy.data.dataset_3d import Dataset3DGeneration\n",
+    "from asgardpy.base.geom import get_source_position, generate_geom\n",
     "from asgardpy.data.target import (\n",
     "    set_models, \n",
     "    apply_selection_mask_to_models,\n",
@@ -227,7 +229,7 @@
    "source": [
     "%%time\n",
     "generate_3d_dataset = Dataset3DGeneration(\n",
-    "    log, config_3d_dataset, config_main\n",
+    "    log, config_3d_dataset, analysis.config\n",
     ")"
    ]
   },
@@ -240,6 +242,16 @@
    "source": [
     "if len(key_names) == 0:\n",
     "    key_names = [None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ddedf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exclusion_regions = []"
    ]
   },
   {
@@ -391,7 +403,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b31f3dd8",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Check if the Spectral Model parameters are properly translated\n",
@@ -471,7 +485,7 @@
     "    source_name = source[\"@name\"]\n",
     "    if source_name not in [\"IsoDiffModel\", \"GalDiffModel\", \"isodiff\", \"galdiff\"]:\n",
     "        source, is_target_source = create_source_skymodel(\n",
-    "            config_main.target, source, aux_path\n",
+    "            analysis.config.target, source, aux_path\n",
     "        )\n",
     "\n",
     "        if is_target_source:\n",
@@ -504,7 +518,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eeb77fb3",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for m in list_sources:\n",
@@ -523,7 +539,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51ab556e",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "target_pos = Models(list_sources)[config_main.target.source_name].spatial_model.position.icrs\n",
@@ -543,7 +561,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d6e2a307",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "plt.figure(figsize=(10,5))\n",
@@ -688,7 +708,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spectral_model, spatial_model = read_models_from_asgardpy_config(config_main.target)"
+    "spectral_model, spatial_model = read_models_from_asgardpy_config(analysis.config.target)"
    ]
   },
   {
@@ -736,9 +756,9 @@
    "source": [
     "list_sources = apply_selection_mask_to_models(\n",
     "    list_sources,\n",
-    "    target_source=config_main.target.source_name,\n",
-    "    roi_radius=config_main.target.roi_selection.roi_radius,\n",
-    "    free_sources=config_main.target.roi_selection.free_sources\n",
+    "    target_source=analysis.config.target.source_name,\n",
+    "    roi_radius=analysis.config.target.roi_selection.roi_radius,\n",
+    "    free_sources=analysis.config.target.roi_selection.free_sources\n",
     ")"
    ]
   },
@@ -746,7 +766,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a5c244ba",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "for m in list_sources:\n",
@@ -780,6 +802,90 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a66a1436",
+   "metadata": {},
+   "source": [
+    "# Get models from Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dc8adab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_geom = generate_geom(\n",
+    "    tag=\"3d\",\n",
+    "    geom_config=analysis.config.dataset3d.instruments[0].dataset_info.geom,\n",
+    "    center_pos=get_source_position(analysis.config.target)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdadde56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis.config.target.use_catalog.selection_radius = 0.2 * u.deg\n",
+    "analysis.config.target.use_catalog.name = \"4fgl\"\n",
+    "list_sources = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4f2fff0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "catalog = CATALOG_REGISTRY.get_cls(analysis.config.target.use_catalog.name)()\n",
+    "print(len(catalog.positions))\n",
+    "\n",
+    "inside_geom = base_geom.to_image().contains(catalog.positions)\n",
+    "\n",
+    "idx_list = np.nonzero(inside_geom)[0]\n",
+    "print(len(idx_list))\n",
+    "\n",
+    "for i in idx_list:\n",
+    "    list_sources.append(catalog[i].sky_model())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73588a1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for m_ in list_sources:\n",
+    "    print(m_.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1573649f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for m_ in list_sources:\n",
+    "    print(m_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23ba0c01",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -798,7 +904,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Have cleaner processing of `AnalysisSteps` based on the data processing stages
- Have better code for model association
- Realize support for adding `FoVBackgroundModel` for 3D datasets by renaming the `extended` boolean to `add_fov_bkg_model` in the `target` config.
- Add support to use Catalogs in Gammapy, when there is no list of models associated with a 3D dataset, for addition or for using it for creating the exclusion mask.
