### PR TITLE
Extend support for updating configs from other configs

### DIFF
--- a/docs/changes/143.feature.rst
+++ b/docs/changes/143.feature.rst
@@ -1,0 +1,1 @@
+Extend the functionality of recursive_merge_dicts when comparing 2 lists of values with different lengths.

--- a/src/asgardpy/config/generator.py
+++ b/src/asgardpy/config/generator.py
@@ -84,7 +84,9 @@ def recursive_merge_dicts(base_config, extra_config):
     update function cannot be used for hierarchical dicts.
 
     Also for the case when there is a list of dicts involved, one has to be
-    more careful.
+    more careful. The extra_config may have longer list of dicts as compared
+    with the base_config, in which case, the extra items are simply added to
+    the merged final list.
 
     Combined here are 2 options from SO.
 
@@ -105,17 +107,27 @@ def recursive_merge_dicts(base_config, extra_config):
         merged dict
     """
     final_config = base_config.copy()
+
     for key, value in extra_config.items():
         if key in final_config and isinstance(final_config[key], list):
             new_config = []
+
             for key_, value_ in zip(final_config[key], value):
                 key_ = recursive_merge_dicts(key_ or {}, value_)
                 new_config.append(key_)
+
+            # For example moving from a smaller list of model parameters to a
+            # longer list.
+            if len(final_config[key]) < len(extra_config[key]):
+                for value_ in value[len(final_config[key]):]:
+                    new_config.append(value_)
             final_config[key] = new_config
+
         elif key in final_config and isinstance(final_config[key], dict):
             final_config[key] = recursive_merge_dicts(final_config.get(key) or {}, value)
         else:
             final_config[key] = value
+
     return final_config
 
 

--- a/src/asgardpy/config/generator.py
+++ b/src/asgardpy/config/generator.py
@@ -119,7 +119,7 @@ def recursive_merge_dicts(base_config, extra_config):
             # For example moving from a smaller list of model parameters to a
             # longer list.
             if len(final_config[key]) < len(extra_config[key]):
-                for value_ in value[len(final_config[key]):]:
+                for value_ in value[len(final_config[key]) :]:
                     new_config.append(value_)
             final_config[key] = new_config
 

--- a/src/asgardpy/config/model_templates/model_template_sbpl.yaml
+++ b/src/asgardpy/config/model_templates/model_template_sbpl.yaml
@@ -46,4 +46,3 @@ target:
               min: 0.0
               max: 5
               frozen: false
-


### PR DESCRIPTION
As from the extra test example, this resolves issues when the other config has a longer list of parameters, as compared with the existing ones.