### PR TITLE
Separate XML model reading functionality into distinct sub-module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        args: ["--profile", "black", "--filter-files", "--multi-line-output", "3"]
+        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:

--- a/docs/changes/154.maintenance.rst
+++ b/docs/changes/154.maintenance.rst
@@ -1,1 +1,1 @@
-Adapt tox env and start using pre-commit hooks. Have CI also run on Mac and Windows OS. Completes the remaining tasks in the Issue [`#127 <https://github.com/chaimain/asgardpy/issues/127>`_].  [`#154 <https://github.com/chaimain/asgardpy/pull/154>`_]
+Adapt tox env and start using pre-commit hooks. Have CI also run on Mac and Windows OS. Completes the remaining tasks in the Issue [`#127 <https://github.com/chaimain/asgardpy/issues/127>`_].

--- a/docs/changes/155.feature.rst
+++ b/docs/changes/155.feature.rst
@@ -1,0 +1,1 @@
+Separate the functionality of reading from a Fermi-XML model file into a distinct function in gammapy module. Completes the Issue [`#153 <https://github.com/chaimain/asgardpy/issues/153>`_].

--- a/docs/source/_api_docs/data/target/data_target_f.rst
+++ b/docs/source/_api_docs/data/target/data_target_f.rst
@@ -5,7 +5,4 @@ asgardpy.data.target module: Functions
 
 .. autofunction:: set_models
 .. autofunction:: config_to_dict
-.. autofunction:: create_source_skymodel
-.. autofunction:: create_gal_diffuse_skymodel
-.. autofunction:: create_iso_diffuse_skymodel
 .. autofunction:: apply_selection_mask_to_models

--- a/docs/source/_api_docs/gammapy/read_models.rst
+++ b/docs/source/_api_docs/gammapy/read_models.rst
@@ -1,0 +1,7 @@
+asgardpy.gammapy.read_models module
+===================================
+
+.. automodule:: asgardpy.gammapy.read_models
+   :members: create_gal_diffuse_skymodel, create_iso_diffuse_skymodel, create_source_skymodel, read_fermi_xml_models_list, update_aux_info_from_fermi_xml
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/additional_model_input.rst
+++ b/docs/source/additional_model_input.rst
@@ -14,7 +14,8 @@ The list of associated Models can be provided by -
     one needs to invoke that module.
 
 #. Using a list of models written in a different way than the Gammapy standard
-    The module :class:`~asgardpy.gammapy.interoperate_models` is used to read such models,
+    The module :class:`~asgardpy.gammapy.read_models` and
+    :class:`~asgardpy.gammapy.interoperate_models` are used to read such models,
     for e.g. XML model definitions used by Fermi-LAT.
 
     A test covering all of these models is included in asgardpy, using a test

--- a/notebooks/test_dataset_3d_step.ipynb
+++ b/notebooks/test_dataset_3d_step.ipynb
@@ -92,8 +92,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 63.2 ms, sys: 4.56 ms, total: 67.7 ms\n",
-      "Wall time: 64.5 ms\n"
+      "CPU times: user 44.8 ms, sys: 2.17 ms, total: 46.9 ms\n",
+      "Wall time: 45.6 ms\n"
      ]
     }
    ],
@@ -232,7 +232,7 @@
        "  'radius': <Angle 0. deg>},\n",
        " 'use_uniform_position': True,\n",
        " 'models_file': PosixPath('.'),\n",
-       " 'add_fov_bkg_model': False,\n",
+       " 'datasets_with_fov_bkg_model': [],\n",
        " 'use_catalog': {'name': '',\n",
        "  'selection_radius': <Angle 0. deg>,\n",
        "  'exclusion_radius': <Angle 0. deg>},\n",
@@ -337,9 +337,7 @@
        "    'key': ['00', '01'],\n",
        "    'observation': {'obs_ids': [],\n",
        "     'obs_file': PosixPath('.'),\n",
-       "     'obs_time': {'format': <TimeFormatEnum.iso: 'iso'>,\n",
-       "      'intervals': [{'start': <Time object: scale='utc' format='iso' value=1970-01-01 00:00:00.000>,\n",
-       "        'stop': <Time object: scale='utc' format='iso' value=2000-01-01 00:00:00.000>}]},\n",
+       "     'obs_time': [],\n",
        "     'obs_cone': {'frame': <FrameEnum.icrs: 'icrs'>,\n",
        "      'lon': <Angle 0. deg>,\n",
        "      'lat': <Angle 0. deg>,\n",
@@ -456,8 +454,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.2 ms, sys: 346 µs, total: 1.55 ms\n",
-      "Wall time: 1.26 ms\n"
+      "CPU times: user 0 ns, sys: 4.83 ms, total: 4.83 ms\n",
+      "Wall time: 3.87 ms\n"
      ]
     }
    ],
@@ -475,7 +473,7 @@
     {
      "data": {
       "text/plain": [
-       "<asgardpy.analysis.analysis.AsgardpyAnalysis at 0x7f5315f55050>"
+       "<asgardpy.analysis.analysis.AsgardpyAnalysis at 0x7f805d58c0d0>"
       ]
      },
      "execution_count": 15,
@@ -564,8 +562,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10 µs, sys: 17 µs, total: 27 µs\n",
-      "Wall time: 40.3 µs\n"
+      "CPU times: user 22 µs, sys: 0 ns, total: 22 µs\n",
+      "Wall time: 32.9 µs\n"
      ]
     }
    ],
@@ -604,7 +602,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "source_name='4FGL J0534.5+2201i' sky_position=SkyPositionConfig(frame=<FrameEnum.icrs: 'icrs'>, lon=<Angle 83.6338333 deg>, lat=<Angle 22.0145 deg>, radius=<Angle 0. deg>) use_uniform_position=True models_file=PosixPath('.') add_fov_bkg_model=False use_catalog=CatalogConfig(name='', selection_radius=<Angle 0. deg>, exclusion_radius=<Angle 0. deg>) components=[ModelComponent(name='4FGL J0534.5+2201i', type=<ModelTypeEnum.skymodel: 'SkyModel'>, datasets_names=[''], spectral=SpectralModelConfig(type='LogParabolaSpectralModel', parameters=[ModelParams(name='amplitude', value=1e-06, unit='cm-2 s-1 TeV-1', error=1.5e-07, min=1e-13, max=0.01, frozen=False), ModelParams(name='reference', value=0.015, unit='TeV', error=0.0, min=0.0001, max=100.0, frozen=True), ModelParams(name='alpha', value=1.7, unit='', error=0.1, min=0.5, max=5.0, frozen=False), ModelParams(name='beta', value=0.1, unit='', error=0.001, min=1e-06, max=1.0, frozen=False)], ebl_abs=EBLAbsorptionModel(filename=PosixPath('.'), reference='dominguez', type='EBLAbsorptionNormSpectralModel', redshift=0.0, alpha_norm=1.0)), spatial=SpatialModelConfig(type='', frame=<FrameEnum.icrs: 'icrs'>, parameters=[ModelParams(name='', value=1.0, unit=' ', error=0.1, min=0.1, max=10.0, frozen=True)]))] covariance='None' from_3d=False roi_selection=RoISelectionConfig(roi_radius=<Angle 0. deg>, free_sources=['4FGL J0521.7+2112', '4FGL J0528.3+1817', '4FGL J0536.2+1733', '4FGL J0534.5+2200'])\n"
+      "source_name='4FGL J0534.5+2201i' sky_position=SkyPositionConfig(frame=<FrameEnum.icrs: 'icrs'>, lon=<Angle 83.6338333 deg>, lat=<Angle 22.0145 deg>, radius=<Angle 0. deg>) use_uniform_position=True models_file=PosixPath('.') datasets_with_fov_bkg_model=[] use_catalog=CatalogConfig(name='', selection_radius=<Angle 0. deg>, exclusion_radius=<Angle 0. deg>) components=[ModelComponent(name='4FGL J0534.5+2201i', type=<ModelTypeEnum.skymodel: 'SkyModel'>, datasets_names=[''], spectral=SpectralModelConfig(type='LogParabolaSpectralModel', parameters=[ModelParams(name='amplitude', value=1e-06, unit='cm-2 s-1 TeV-1', error=1.5e-07, min=1e-13, max=0.01, frozen=False), ModelParams(name='reference', value=0.015, unit='TeV', error=0.0, min=0.0001, max=100.0, frozen=True), ModelParams(name='alpha', value=1.7, unit='', error=0.1, min=0.5, max=5.0, frozen=False), ModelParams(name='beta', value=0.1, unit='', error=0.001, min=1e-06, max=1.0, frozen=False)], ebl_abs=EBLAbsorptionModel(filename=PosixPath('.'), reference='dominguez', type='EBLAbsorptionNormSpectralModel', redshift=0.0, alpha_norm=1.0)), spatial=SpatialModelConfig(type='', frame=<FrameEnum.icrs: 'icrs'>, parameters=[ModelParams(name='', value=1.0, unit=' ', error=0.1, min=0.1, max=10.0, frozen=True)]))] covariance='None' from_3d=False roi_selection=RoISelectionConfig(roi_radius=<Angle 0. deg>, free_sources=['4FGL J0521.7+2112', '4FGL J0528.3+1817', '4FGL J0536.2+1733', '4FGL J0534.5+2200'])\n"
      ]
     }
    ],
@@ -676,7 +674,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'gal_diffuse': None, 'iso_diffuse': None, 'gal_diffuse_cutout': None}\n"
+      "{'gal_diffuse': None, 'iso_diffuse': None, 'key_name': None, 'gal_diffuse_cutout': None}\n"
      ]
     }
    ],
@@ -699,7 +697,7 @@
     }
    ],
    "source": [
-    "print(generate_3d_dataset.list_sources)"
+    "print(generate_3d_dataset.list_source_models)"
    ]
   },
   {
@@ -752,8 +750,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.23 s, sys: 58.2 ms, total: 1.29 s\n",
-      "Wall time: 1.28 s\n"
+      "CPU times: user 1.18 s, sys: 68.3 ms, total: 1.25 s\n",
+      "Wall time: 1.25 s\n"
      ]
     }
    ],
@@ -899,14 +897,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WcsNDMap\n",
+      "SkyModel\n",
       "\n",
-      "\tgeom  : WcsGeom \n",
-      " \taxes  : ['lon', 'lat', 'energy_true']\n",
-      "\tshape : (124, 176, 28)\n",
-      "\tndim  : 3\n",
-      "\tunit  : 1 / (MeV s sr cm2)\n",
-      "\tdtype : >f4\n",
+      "  Name                      : diffuse-iem\n",
+      "  Datasets names            : None\n",
+      "  Spectral model type       : PowerLawNormSpectralModel\n",
+      "  Spatial  model type       : TemplateSpatialModel\n",
+      "  Temporal model type       : \n",
+      "  Parameters:\n",
+      "    norm                          :      1.000   +/-    0.00             \n",
+      "    tilt                  (frozen):      0.000                   \n",
+      "    reference             (frozen):      1.000       TeV         \n",
+      "\n",
       "\n"
      ]
     }
@@ -962,7 +964,7 @@
     }
    ],
    "source": [
-    "print(len(generate_3d_dataset.list_sources), \"number of sources read from XML file\")"
+    "print(len(generate_3d_dataset.list_source_models), \"number of sources read from XML file\")"
    ]
   },
   {
@@ -1828,7 +1830,7 @@
     }
    ],
    "source": [
-    "for src in generate_3d_dataset.list_sources:\n",
+    "for src in generate_3d_dataset.list_source_models:\n",
     "    print(src)"
    ]
   },
@@ -1847,7 +1849,7 @@
     }
    ],
    "source": [
-    "print(\"Number of free parameters in the whole list of SkyModels:\", len(Models(generate_3d_dataset.list_sources).parameters.free_parameters))"
+    "print(\"Number of free parameters in the whole list of SkyModels:\", len(Models(generate_3d_dataset.list_source_models).parameters.free_parameters))"
    ]
   },
   {
@@ -1865,7 +1867,7 @@
     }
    ],
    "source": [
-    "print(\"Names of the sources in the whole list of SkyModels:\", Models(generate_3d_dataset.list_sources).names)"
+    "print(\"Names of the sources in the whole list of SkyModels:\", Models(generate_3d_dataset.list_source_models).names)"
    ]
   },
   {
@@ -1894,8 +1896,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.8 ms, sys: 1.74 ms, total: 12.6 ms\n",
-      "Wall time: 10.9 ms\n"
+      "CPU times: user 9.43 ms, sys: 4.13 ms, total: 13.6 ms\n",
+      "Wall time: 12.5 ms\n"
      ]
     }
    ],
@@ -1961,8 +1963,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 70.3 ms, sys: 18.1 ms, total: 88.4 ms\n",
-      "Wall time: 85.1 ms\n"
+      "CPU times: user 71.1 ms, sys: 26 ms, total: 97.1 ms\n",
+      "Wall time: 99.7 ms\n"
      ]
     }
    ],
@@ -2047,8 +2049,8 @@
      "text": [
       "{'center': <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg\n",
       "    (83.633, 22.02)>, 'radius': 11.10660172}\n",
-      "CPU times: user 7.55 ms, sys: 3.56 ms, total: 11.1 ms\n",
-      "Wall time: 3.7 ms\n"
+      "CPU times: user 5.19 ms, sys: 2.14 ms, total: 7.32 ms\n",
+      "Wall time: 7.18 ms\n"
      ]
     }
    ],
@@ -2088,8 +2090,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.21 s, sys: 69.2 ms, total: 2.28 s\n",
-      "Wall time: 2.28 s\n"
+      "CPU times: user 2.39 s, sys: 71 ms, total: 2.46 s\n",
+      "Wall time: 2.46 s\n"
      ]
     }
    ],
@@ -2147,7 +2149,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2e16d5345e342988604ce66d0d03a3d",
+       "model_id": "1215a343bde74355ae50c2cdf7a3b67b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2222,8 +2224,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 448 ms, sys: 100 ms, total: 548 ms\n",
-      "Wall time: 491 ms\n"
+      "CPU times: user 537 ms, sys: 111 ms, total: 648 ms\n",
+      "Wall time: 622 ms\n"
      ]
     }
    ],
@@ -2276,7 +2278,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "378d4e413bd4482a8efdce5e01a5df4e",
+       "model_id": "c7c2518cf20347c5970adf7c261258bf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2318,8 +2320,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.53 ms, sys: 5.22 ms, total: 11.8 ms\n",
-      "Wall time: 3.41 ms\n"
+      "CPU times: user 6.32 ms, sys: 15.5 ms, total: 21.8 ms\n",
+      "Wall time: 6.33 ms\n"
      ]
     }
    ],
@@ -2377,8 +2379,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 969 ms, sys: 82.8 ms, total: 1.05 s\n",
-      "Wall time: 1.05 s\n"
+      "CPU times: user 1 s, sys: 134 ms, total: 1.14 s\n",
+      "Wall time: 1.13 s\n"
      ]
     }
    ],
@@ -2439,8 +2441,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 21.4 ms, sys: 5.85 ms, total: 27.3 ms\n",
-      "Wall time: 24.5 ms\n"
+      "CPU times: user 37.4 ms, sys: 7.97 ms, total: 45.3 ms\n",
+      "Wall time: 43.2 ms\n"
      ]
     }
    ],
@@ -2476,7 +2478,7 @@
     }
    ],
    "source": [
-    "print(Models(generate_3d_dataset.list_sources)[\"diffuse-iem\"])"
+    "print(Models(generate_3d_dataset.list_source_models)[\"diffuse-iem\"])"
    ]
   },
   {
@@ -2532,8 +2534,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generate_3d_dataset.list_sources = apply_selection_mask_to_models(\n",
-    "    generate_3d_dataset.list_sources,\n",
+    "generate_3d_dataset.list_source_models = apply_selection_mask_to_models(\n",
+    "    generate_3d_dataset.list_source_models,\n",
     "    target_source=generate_3d_dataset.config_target.source_name,\n",
     "    selection_mask=generate_3d_dataset.exclusion_mask,\n",
     ")"
@@ -2709,7 +2711,7 @@
     }
    ],
    "source": [
-    "for m in generate_3d_dataset.list_sources:\n",
+    "for m in generate_3d_dataset.list_source_models:\n",
     "    print(m)"
    ]
   },
@@ -2746,8 +2748,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.6 ms, sys: 1.4 ms, total: 14 ms\n",
-      "Wall time: 11.7 ms\n"
+      "CPU times: user 9.26 ms, sys: 2.18 ms, total: 11.4 ms\n",
+      "Wall time: 10.2 ms\n"
      ]
     }
    ],
@@ -2983,7 +2985,7 @@
     }
    ],
    "source": [
-    "for m in generate_3d_dataset.list_sources:\n",
+    "for m in generate_3d_dataset.list_source_models:\n",
     "    print(m)"
    ]
   },
@@ -3013,14 +3015,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.54 ms, sys: 0 ns, total: 2.54 ms\n",
-      "Wall time: 2.48 ms\n"
+      "CPU times: user 3.86 ms, sys: 0 ns, total: 3.86 ms\n",
+      "Wall time: 3.77 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "dataset.models = generate_3d_dataset.list_sources"
+    "dataset.models = generate_3d_dataset.list_source_models"
    ]
   },
   {
@@ -3217,8 +3219,8 @@
       "      reference             (frozen):      1.000       TeV         \n",
       "  \n",
       "  \n",
-      "CPU times: user 13.5 s, sys: 7.06 s, total: 20.6 s\n",
-      "Wall time: 20.6 s\n"
+      "CPU times: user 13.7 s, sys: 8.94 s, total: 22.6 s\n",
+      "Wall time: 22.6 s\n"
      ]
     }
    ],
@@ -3254,7 +3256,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a0cae6857af44bbda035e86966eeac63",
+       "model_id": "d30abd906bc144e5a61e367315dfff07",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3477,7 +3479,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7998f94f3ee04abca0f135ba68700933",
+       "model_id": "749459b14ca84bc1ab082ba3f629f03b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3545,7 +3547,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f53121ccc50>"
+       "<matplotlib.legend.Legend at 0x7f805be8fc10>"
       ]
      },
      "execution_count": 73,

--- a/notebooks/test_models.ipynb
+++ b/notebooks/test_models.ipynb
@@ -8,16 +8,14 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
     "import xmltodict\n",
-    "from astropy.coordinates import SkyCoord\n",
-    "import astropy.units as u\n",
+    "from pathlib import Path\n",
     "import numpy as np\n",
     "import logging\n",
     "\n",
-    "from asgardpy.analysis import AsgardpyAnalysis\n",
-    "from asgardpy.config import AsgardpyConfig\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
     "\n",
     "from gammapy.catalog import CATALOG_REGISTRY\n",
     "from gammapy.modeling.models import Models, SPECTRAL_MODEL_REGISTRY, SPATIAL_MODEL_REGISTRY\n",
@@ -31,18 +29,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from asgardpy.analysis import AsgardpyAnalysis\n",
+    "from asgardpy.config import AsgardpyConfig\n",
+    "\n",
     "from asgardpy.data.dataset_3d import Dataset3DGeneration\n",
     "from asgardpy.base.geom import get_source_position, generate_geom\n",
     "from asgardpy.data.target import (\n",
     "    set_models, \n",
     "    apply_selection_mask_to_models,\n",
-    "    create_gal_diffuse_skymodel, \n",
-    "    create_source_skymodel, \n",
     "    read_models_from_asgardpy_config\n",
     ")\n",
     "from asgardpy.gammapy.interoperate_models import (\n",
     "    xml_spectral_model_to_gammapy,\n",
     "    xml_spatial_model_to_gammapy,\n",
+    ")\n",
+    "from asgardpy.gammapy.read_models import (\n",
+    "    create_gal_diffuse_skymodel, \n",
+    "    create_source_skymodel,\n",
+    "    read_fermi_xml_models_list,\n",
     ")"
    ]
   },
@@ -67,8 +71,102 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7255820e-896c-465c-a42b-6f8c52e7b0bc",
+   "metadata": {},
+   "source": [
+    "# Using asgardpy.gammapy.read_models class directly"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "6a35eecb-711b-40ec-a6fc-c1bd2cc056b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_source_models = []\n",
+    "diffuse_models = {}\n",
+    "\n",
+    "dl3_dl3_aux_path = Path(f\"{os.environ['GAMMAPY_DATA']}fermipy-crab/\")\n",
+    "\n",
+    "xml_file = dl3_dl3_aux_path / \"srcmdl_00.xml\"\n",
+    "\n",
+    "# Diffuse models if need to be read, else can be kept as an empty dict\n",
+    "diffuse_models[\"gal_diffuse\"] = dl3_dl3_aux_path / \"gll_iem_v07_cutout.fits\"\n",
+    "diffuse_models[\"iso_diffuse\"] = dl3_dl3_aux_path / \"iso_P8R3_SOURCE_V3_FRONT_v1.txt\"\n",
+    "diffuse_models[\"key_name\"] = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "421ffd0b-ec0f-4f0a-9e45-96ed9967c3be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.2 s, sys: 37.1 ms, total: 1.24 s\n",
+      "Wall time: 1.24 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "list_source_models, diffuse_models = read_fermi_xml_models_list(\n",
+    "    list_source_models, dl3_dl3_aux_path, xml_file, diffuse_models\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "742b3a49-e0a9-42c9-9c69-fd1fdfd46ded",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_source_models = Models(list_source_models)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ac50d08f-01f0-46c4-9364-f05b797ad3e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['4FGL J0534.5+2201i', '4FGL J0534.5+2201s', '4FGL J0534.5+2200', '4FGL J0526.3+2246', '4FGL J0544.4+2238', '4FGL J0521.7+2112', '4FGL J0528.3+1817', '4FGL J0536.2+1733', '4FGL J0550.9+2552c', '4FGL J0539.0+1644', '4FGL J0534.2+2751', '4FGL J0540.3+2756e', '4FGL J0521.2+1637', '4FGL J0552.0+2656c', '4FGL J0601.4+2320', '4FGL J0509.1+1943', '4FGL J0533.9+2838', '4FGL J0519.6+2744', '4FGL J0603.9+2159', '4FGL J0510.0+1800', '4FGL J0524.5+2839', '4FGL J0533.5+1449', '4FGL J0539.6+1432', '4FGL J0515.8+1527', '4FGL J0609.0+2136c', '4FGL J0501.0+2424', '4FGL J0608.8+2034c', '4FGL J0609.0+2006', '4FGL J0530.9+1332', '4FGL J0459.4+1921', '4FGL J0531.7+1241c', '4FGL J0614.9+2426', '4FGL J0616.5+2235', '4FGL J0617.2+2234e', '4FGL J0610.7+1656', '4FGL J0452.0+2100', '4FGL J0540.0+1209', '4FGL J0613.1+1749c', '4FGL J0456.2+2702', '4FGL J0554.1+3107', '4FGL J0611.6+2803', '4FGL J0559.6+3044', '4FGL J0548.6+1200', '4FGL J0502.2+3016', '4FGL J0600.3+1244', '4FGL J0612.6+1520c', '4FGL J0502.5+1340', '4FGL J0501.7+3048', '4FGL J0453.3+2843', '4FGL J0609.5+1402', '4FGL J0608.6+1149', '4FGL J0449.6+3027', '4FGL J0458.0+1152', 'fermi-diffuse-iso', 'diffuse-iem']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list_source_models.names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb71aafd-75d1-40ec-93ca-675fc8215bf6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a29cf98-c497-44b3-962e-a52fdb1e8284",
+   "metadata": {},
+   "source": [
+    "# Using AsgardpyConfig specific functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "id": "c68f07a5",
    "metadata": {},
    "outputs": [],
@@ -78,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "id": "6143dfdf",
    "metadata": {},
    "outputs": [],
@@ -88,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "id": "d3400f37",
    "metadata": {},
    "outputs": [
@@ -96,8 +194,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 62 ms, sys: 4.83 ms, total: 66.8 ms\n",
-      "Wall time: 63.8 ms\n"
+      "CPU times: user 53.4 ms, sys: 6.73 ms, total: 60.1 ms\n",
+      "Wall time: 57.4 ms\n"
      ]
     }
    ],
@@ -124,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "6220d17d-8c42-4b8b-a232-26ad29436e47",
    "metadata": {},
    "outputs": [],
@@ -144,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "a531e6ed",
    "metadata": {
     "scrolled": true
@@ -169,7 +267,7 @@
        " 'stacked_dataset': True}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "2de0184b",
    "metadata": {},
    "outputs": [
@@ -201,7 +299,7 @@
        " <AnalysisStepEnum.flux_points: 'flux-points'>]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "5034abda",
    "metadata": {
     "scrolled": true
@@ -236,7 +334,7 @@
        "  'radius': <Angle 0. deg>},\n",
        " 'use_uniform_position': True,\n",
        " 'models_file': PosixPath('.'),\n",
-       " 'add_fov_bkg_model': False,\n",
+       " 'datasets_with_fov_bkg_model': [],\n",
        " 'use_catalog': {'name': '',\n",
        "  'selection_radius': <Angle 0. deg>,\n",
        "  'exclusion_radius': <Angle 0. deg>},\n",
@@ -295,7 +393,7 @@
        "   '4FGL J0534.5+2200']}}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -314,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "id": "40fabea9",
    "metadata": {
     "scrolled": true
@@ -341,9 +439,7 @@
        "    'key': ['00', '01'],\n",
        "    'observation': {'obs_ids': [],\n",
        "     'obs_file': PosixPath('.'),\n",
-       "     'obs_time': {'format': <TimeFormatEnum.iso: 'iso'>,\n",
-       "      'intervals': [{'start': <Time object: scale='utc' format='iso' value=1970-01-01 00:00:00.000>,\n",
-       "        'stop': <Time object: scale='utc' format='iso' value=2000-01-01 00:00:00.000>}]},\n",
+       "     'obs_time': [],\n",
        "     'obs_cone': {'frame': <FrameEnum.icrs: 'icrs'>,\n",
        "      'lon': <Angle 0. deg>,\n",
        "      'lat': <Angle 0. deg>,\n",
@@ -408,7 +504,7 @@
        "     'axis_custom': {'edges': [], 'unit': 'TeV'}}}}]}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "1a8f0690",
    "metadata": {},
    "outputs": [
@@ -442,8 +538,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.9 ms, sys: 825 µs, total: 2.73 ms\n",
-      "Wall time: 1.9 ms\n"
+      "CPU times: user 2.03 ms, sys: 44 µs, total: 2.08 ms\n",
+      "Wall time: 1.48 ms\n"
      ]
     }
    ],
@@ -454,17 +550,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "id": "dd6588f1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<asgardpy.analysis.analysis.AsgardpyAnalysis at 0x7f45077d1f90>"
+       "<asgardpy.analysis.analysis.AsgardpyAnalysis at 0x7f0d6dd25c90>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -491,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "ab46c633",
    "metadata": {},
    "outputs": [
@@ -518,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "id": "54c923a4",
    "metadata": {},
    "outputs": [
@@ -526,8 +622,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11 µs, sys: 20 µs, total: 31 µs\n",
-      "Wall time: 46.5 µs\n"
+      "CPU times: user 13 µs, sys: 17 µs, total: 30 µs\n",
+      "Wall time: 43.9 µs\n"
      ]
     }
    ],
@@ -540,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "id": "f33f9e63",
    "metadata": {},
    "outputs": [],
@@ -551,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "id": "69ddedf2",
    "metadata": {},
    "outputs": [],
@@ -561,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "id": "91a0d1d7",
    "metadata": {
     "scrolled": true
@@ -591,8 +687,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.35 s, sys: 58.7 ms, total: 1.41 s\n",
-      "Wall time: 1.41 s\n"
+      "CPU times: user 1.27 s, sys: 75 ms, total: 1.35 s\n",
+      "Wall time: 1.35 s\n"
      ]
     }
    ],
@@ -603,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "id": "5ec6f406",
    "metadata": {},
    "outputs": [
@@ -638,7 +734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "id": "046633e6",
    "metadata": {},
    "outputs": [],
@@ -649,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "id": "bf017e25",
    "metadata": {
     "scrolled": true
@@ -734,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "id": "ca80df20",
    "metadata": {
     "scrolled": true
@@ -770,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "id": "2b1c1f6f",
    "metadata": {},
    "outputs": [
@@ -795,13 +891,12 @@
     }
    ],
    "source": [
-    "diff_gal = create_gal_diffuse_skymodel(generate_3d_dataset.diffuse_models[\"gal_diffuse\"])\n",
-    "print(diff_gal)"
+    "print(generate_3d_dataset.diffuse_models[\"gal_diffuse\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "id": "3d275500",
    "metadata": {},
    "outputs": [
@@ -814,8 +909,8 @@
     }
    ],
    "source": [
-    "aux_path = generate_3d_dataset.config_3d_dataset.input_dl3[1].input_dir\n",
-    "print(aux_path)"
+    "dl3_aux_path = generate_3d_dataset.config_3d_dataset.input_dl3[1].input_dir\n",
+    "print(dl3_aux_path)"
    ]
   },
   {
@@ -828,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "id": "dbfbc6c5",
    "metadata": {
     "scrolled": true
@@ -925,7 +1020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "id": "b31f3dd8",
    "metadata": {
     "scrolled": true
@@ -2026,40 +2121,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 32,
    "id": "1682a992",
    "metadata": {},
    "outputs": [],
    "source": [
-    "list_sources = []\n",
+    "list_source_models = []\n",
     "is_target_source = False\n",
     "\n",
     "for source in data:\n",
     "    source_name = source[\"@name\"]\n",
     "    if source_name not in [\"IsoDiffModel\", \"GalDiffModel\", \"isodiff\", \"galdiff\"]:\n",
     "        source, is_target_source = create_source_skymodel(\n",
-    "            analysis.config.target, source, aux_path\n",
+    "            source, dl3_aux_path, asgardpy_target_config=analysis.config.target\n",
     "        )\n",
     "\n",
     "        if is_target_source:\n",
-    "            list_sources.insert(0, source)\n",
+    "            list_source_models.insert(0, source)\n",
     "        else:\n",
-    "            list_sources.append(source)"
+    "            list_source_models.append(source)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 33,
    "id": "b3f6b7fe",
    "metadata": {},
    "outputs": [],
    "source": [
-    "list_sources.append(generate_3d_dataset.diffuse_models[\"iso_diffuse\"])"
+    "list_source_models.append(generate_3d_dataset.diffuse_models[\"iso_diffuse\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 34,
    "id": "0e7983c4",
    "metadata": {},
    "outputs": [
@@ -2072,12 +2167,12 @@
     }
    ],
    "source": [
-    "print(len(list_sources))"
+    "print(len(list_source_models))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 35,
    "id": "eeb77fb3",
    "metadata": {
     "scrolled": true
@@ -2924,7 +3019,7 @@
     }
    ],
    "source": [
-    "for m in list_sources:\n",
+    "for m in list_source_models:\n",
     "    print(m)"
    ]
   },
@@ -2938,7 +3033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 36,
    "id": "51ab556e",
    "metadata": {
     "scrolled": true
@@ -3349,8 +3444,8 @@
     }
    ],
    "source": [
-    "target_pos = Models(list_sources)[config_main.target.source_name].spatial_model.position.icrs\n",
-    "for m in list_sources:\n",
+    "target_pos = Models(list_source_models)[config_main.target.source_name].spatial_model.position.icrs\n",
+    "for m in list_source_models:\n",
     "    print(\"\\n\", m.name)\n",
     "    if m.spatial_model.position:\n",
     "        print(f\"Separation from Target source is {target_pos.separation(m.spatial_model.position.icrs).deg:.3f} deg\")\n",
@@ -3364,7 +3459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 37,
    "id": "d6e2a307",
    "metadata": {
     "scrolled": true
@@ -3376,7 +3471,7 @@
        "(1e-13, 1e-08)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -3394,7 +3489,7 @@
    "source": [
     "plt.figure(figsize=(10,5))\n",
     "en_b = [1e-4, 1e2] * u.TeV\n",
-    "for m in list_sources:\n",
+    "for m in list_source_models:\n",
     "    if m.spatial_model.position:\n",
     "        label_ = f\"{m.name} {target_pos.separation(m.spatial_model.position.icrs).deg:.1e} deg\"\n",
     "    else:\n",
@@ -3402,7 +3497,7 @@
     "    m.spectral_model.plot(energy_bounds=en_b, sed_type=\"e2dnde\", label=label_)\n",
     "\n",
     "plt.grid()\n",
-    "plt.legend(bbox_to_anchor=(1,1), ncols=int(np.sqrt(len(list_sources))/2))\n",
+    "plt.legend(bbox_to_anchor=(1,1), ncols=int(np.sqrt(len(list_source_models))/2))\n",
     "plt.ylim(1e-13, 1e-8)"
    ]
   },
@@ -3424,7 +3519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 38,
    "id": "233bc74c",
    "metadata": {},
    "outputs": [
@@ -3735,7 +3830,7 @@
     "\n",
     "    elif xml_spatial_model[\"@type\"] == \"SpatialMap\":\n",
     "        file_name = xml_spatial_model[\"@file\"].split(\"/\")[-1]\n",
-    "        file_path = aux_path / f\"Templates/{file_name}\"\n",
+    "        file_path = dl3_aux_path / f\"Templates/{file_name}\"\n",
     "\n",
     "        spatial_map = Map.read(file_path)\n",
     "        spatial_map = spatial_map.copy(unit=\"sr^-1\")\n",
@@ -3770,7 +3865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 39,
    "id": "8c00125c",
    "metadata": {},
    "outputs": [
@@ -4215,14 +4310,14 @@
     }
    ],
    "source": [
-    "for m in list_sources:\n",
+    "for m in list_source_models:\n",
     "    print(\"\\n\", m.name, m.spatial_model.tag)\n",
     "    print(m.spatial_model, m.spatial_model.evaluation_radius)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 40,
    "id": "e2398302",
    "metadata": {
     "scrolled": true
@@ -4249,7 +4344,7 @@
        "<WCSAxes: >"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -4266,8 +4361,8 @@
    ],
    "source": [
     "idx = 0\n",
-    "print(list_sources[idx].name, list_sources[idx].spatial_model)\n",
-    "test_ = list_sources[idx].spatial_model\n",
+    "print(list_source_models[idx].name, list_source_models[idx].spatial_model)\n",
+    "test_ = list_source_models[idx].spatial_model\n",
     "test_.plot(add_cbar=True)"
    ]
   },
@@ -4289,7 +4384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 41,
    "id": "6891589c",
    "metadata": {},
    "outputs": [],
@@ -4299,7 +4394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 42,
    "id": "ff52299f",
    "metadata": {
     "scrolled": true
@@ -4335,7 +4430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 43,
    "id": "7a4a0290",
    "metadata": {},
    "outputs": [
@@ -4369,13 +4464,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 44,
    "id": "d65dafc0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "list_sources = apply_selection_mask_to_models(\n",
-    "    list_sources,\n",
+    "list_source_models = apply_selection_mask_to_models(\n",
+    "    list_source_models,\n",
     "    target_source=analysis.config.target.source_name,\n",
     "    roi_radius=analysis.config.target.roi_selection.roi_radius,\n",
     "    free_sources=analysis.config.target.roi_selection.free_sources\n",
@@ -4384,7 +4479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 45,
    "id": "a5c244ba",
    "metadata": {
     "scrolled": true
@@ -5231,13 +5326,13 @@
     }
    ],
    "source": [
-    "for m in list_sources:\n",
+    "for m in list_source_models:\n",
     "    print(m)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 46,
    "id": "c8057338",
    "metadata": {},
    "outputs": [
@@ -5250,12 +5345,12 @@
     }
    ],
    "source": [
-    "print(len(list_sources))"
+    "print(len(list_source_models))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 47,
    "id": "4d3dec2a",
    "metadata": {},
    "outputs": [
@@ -5268,7 +5363,7 @@
     }
    ],
    "source": [
-    "print(len(list_sources.parameters.free_parameters))"
+    "print(len(list_source_models.parameters.free_parameters))"
    ]
   },
   {
@@ -5289,7 +5384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 48,
    "id": "2dc8adab",
    "metadata": {},
    "outputs": [],
@@ -5303,19 +5398,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 49,
    "id": "fdadde56",
    "metadata": {},
    "outputs": [],
    "source": [
     "analysis.config.target.use_catalog.selection_radius = 0.2 * u.deg\n",
     "analysis.config.target.use_catalog.name = \"4fgl\"\n",
-    "list_sources = []"
+    "list_source_models = []"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 50,
    "id": "b4f2fff0",
    "metadata": {
     "scrolled": true
@@ -5327,8 +5422,8 @@
      "text": [
       "6659\n",
       "4\n",
-      "CPU times: user 738 ms, sys: 156 ms, total: 894 ms\n",
-      "Wall time: 1.11 s\n"
+      "CPU times: user 740 ms, sys: 173 ms, total: 913 ms\n",
+      "Wall time: 1.03 s\n"
      ]
     }
    ],
@@ -5343,12 +5438,12 @@
     "print(len(idx_list))\n",
     "\n",
     "for i in idx_list:\n",
-    "    list_sources.append(catalog[i].sky_model())\n"
+    "    list_source_models.append(catalog[i].sky_model())\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 51,
    "id": "73588a1f",
    "metadata": {},
    "outputs": [
@@ -5364,13 +5459,13 @@
     }
    ],
    "source": [
-    "for m_ in list_sources:\n",
+    "for m_ in list_source_models:\n",
     "    print(m_.name)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 52,
    "id": "1573649f",
    "metadata": {
     "scrolled": true
@@ -5451,7 +5546,7 @@
     }
    ],
    "source": [
-    "for m_ in list_sources:\n",
+    "for m_ in list_source_models:\n",
     "    print(m_)"
    ]
   },

--- a/src/asgardpy/data/__init__.py
+++ b/src/asgardpy/data/__init__.py
@@ -25,9 +25,6 @@ from asgardpy.data.target import (
     Target,
     apply_selection_mask_to_models,
     config_to_dict,
-    create_gal_diffuse_skymodel,
-    create_iso_diffuse_skymodel,
-    create_source_skymodel,
     set_models,
 )
 
@@ -47,8 +44,5 @@ __all__ = [
     "Target",
     "apply_selection_mask_to_models",
     "config_to_dict",
-    "create_gal_diffuse_skymodel",
-    "create_iso_diffuse_skymodel",
-    "create_source_skymodel",
     "set_models",
 ]

--- a/src/asgardpy/gammapy/__init__.py
+++ b/src/asgardpy/gammapy/__init__.py
@@ -6,9 +6,21 @@ from asgardpy.gammapy.interoperate_models import (
     xml_spatial_model_to_gammapy,
     xml_spectral_model_to_gammapy,
 )
+from asgardpy.gammapy.read_models import (
+    create_gal_diffuse_skymodel,
+    create_iso_diffuse_skymodel,
+    create_source_skymodel,
+    read_fermi_xml_models_list,
+    update_aux_info_from_fermi_xml,
+)
 
 __all__ = [
     "get_gammapy_spectral_model",
     "xml_spatial_model_to_gammapy",
     "xml_spectral_model_to_gammapy",
+    "create_gal_diffuse_skymodel",
+    "create_iso_diffuse_skymodel",
+    "create_source_skymodel",
+    "read_fermi_xml_models_list",
+    "update_aux_info_from_fermi_xml",
 ]

--- a/src/asgardpy/gammapy/interoperate_models.py
+++ b/src/asgardpy/gammapy/interoperate_models.py
@@ -247,7 +247,6 @@ def xml_spectral_model_to_gammapy(
             new_par, spectrum_type, en_scale_1_to_gpy=en_scale_1_to_gpy, keep_sign=keep_sign
         )
 
-        # For Fermi-XML model
         if base_model_type == "Fermi-XML":
             if new_par["name"] == "alpha" and spectrum_type in [
                 "PLSuperExpCutoff",
@@ -270,7 +269,6 @@ def xml_spectral_model_to_gammapy(
     params_final2 = Parameters(new_params)
 
     # Modifications when different parameters are interconnected
-    # For Fermi-XML model
     if base_model_type == "Fermi-XML":
         if spectrum_type == "PLSuperExpCutoff2":
             alpha_inv = 1 / params_final2["alpha"].value

--- a/src/asgardpy/gammapy/read_models.py
+++ b/src/asgardpy/gammapy/read_models.py
@@ -28,8 +28,6 @@ __all__ = [
 ]
 
 
-## Try to make these functions as independent of AConfig as possible
-## Make these self-reliant
 def read_fermi_xml_models_list(
     list_source_models, dl3_aux_path, xml_file, diffuse_models, asgardpy_target_config=None
 ):

--- a/src/asgardpy/gammapy/read_models.py
+++ b/src/asgardpy/gammapy/read_models.py
@@ -1,0 +1,319 @@
+"""
+Functions for reading different Models type objects with Gammapy
+objects.
+"""
+import xmltodict
+from gammapy.maps import Map
+from gammapy.modeling.models import (
+    SPATIAL_MODEL_REGISTRY,
+    SPECTRAL_MODEL_REGISTRY,
+    EBLAbsorptionNormSpectralModel,
+    SkyModel,
+    create_fermi_isotropic_diffuse_model,
+)
+
+from asgardpy.data.target import read_models_from_asgardpy_config
+from asgardpy.gammapy.interoperate_models import (
+    get_gammapy_spectral_model,
+    xml_spatial_model_to_gammapy,
+    xml_spectral_model_to_gammapy,
+)
+
+__all__ = [
+    "create_gal_diffuse_skymodel",
+    "create_iso_diffuse_skymodel",
+    "create_source_skymodel",
+    "read_fermi_xml_models_list",
+    "update_aux_info_from_fermi_xml",
+]
+
+
+## Try to make these functions as independent of AConfig as possible
+## Make these self-reliant
+def read_fermi_xml_models_list(
+    list_source_models, dl3_aux_path, xml_file, diffuse_models, asgardpy_target_config=None
+):
+    """
+    Read from the Fermi-XML file to enlist the various objects and get their
+    SkyModels.
+
+    Parameters
+    ----------
+    list_source_models: list
+        List of source models to be filled.
+    dl3_aux_path: str
+        Path location of the DL3 auxiliary files for reading Spatial Models
+        from separate files.
+    xml_file: str
+        Path of the Fermi-XML file to be read.
+    diffuse_models: dict
+        Dict containing diffuse models' filenames and instrument key.
+    asgardpy_target_config: `AsgardpyConfig`
+        Config section containing the Target source information.
+
+    Returns
+    -------
+    list_source_models: list
+        List of filled source models.
+    diffuse_models: dict
+        Dict containing diffuse models objects replacing the filenames.
+    """
+    with open(xml_file, encoding="utf-8") as file:
+        xml_data = xmltodict.parse(file.read())["source_library"]["source"]
+
+    is_target_source = False
+    for source_info in xml_data:
+        source_name = source_info["@name"]
+
+        # Nomenclature as per enrico and fermipy
+        if source_name in ["IsoDiffModel", "isodiff"]:
+            diffuse_models["iso_diffuse"] = create_iso_diffuse_skymodel(
+                diffuse_models["iso_diffuse"], diffuse_models["key_name"]
+            )
+            source_info = diffuse_models["iso_diffuse"]
+        elif source_name in ["GalDiffModel", "galdiff"]:
+            diffuse_models["gal_diffuse"], diffuse_models["gal_diffuse_map"] = create_gal_diffuse_skymodel(
+                diffuse_models["gal_diffuse"]
+            )
+            source_info = diffuse_models["gal_diffuse"]
+        else:
+            source_info, is_target_source = create_source_skymodel(
+                source_info,
+                dl3_aux_path,
+                base_model_type="Fermi-XML",
+                asgardpy_target_config=asgardpy_target_config,
+            )
+        if is_target_source:
+            list_source_models.insert(0, source_info)
+            is_target_source = False  # To not let it repeat
+        else:
+            list_source_models.append(source_info)
+
+    return list_source_models, diffuse_models
+
+
+def update_aux_info_from_fermi_xml(
+    diffuse_models_file_names_dict, xml_file, fetch_iso_diff=False, fetch_gal_diff=False
+):
+    """
+    When no glob_search patterns on axuillary files are provided, fetch
+    them from the XML file and update the dict containing diffuse models' file
+    names.
+
+    Parameters
+    ----------
+    diffuse_models_file_names_dict: `dict`
+        Dict containing the information on the DL3 files input.
+    xml_file: str
+        Path of the Fermi-XML file to be read.
+    fetch_iso_diff: bool
+        Boolean to get the information of the Isotropic diffuse model from the
+        Fermi-XML file
+    fetch_gal_diff: bool
+        Boolean to get the information of the Galactic diffuse model from the
+        Fermi-XML file
+
+    Returns
+    -------
+    diffuse_models_file_names_dict: `dict`
+        Dict containing the updated information on the DL3 files input.
+    """
+    with open(xml_file) as file:
+        data = xmltodict.parse(file.read())["source_library"]["source"]
+
+    for source in data:
+        source_name = source["@name"]
+        if source_name in ["IsoDiffModel", "isodiff"]:
+            if fetch_iso_diff:
+                file_path = source["spectrum"]["@file"]
+                file_name = file_path.split("/")[-1]
+                diffuse_models_file_names_dict["iso_diffuse"] = file_name
+        if source_name in ["GalDiffModel", "galdiff"]:
+            if fetch_gal_diff:
+                file_path = source["spatialModel"]["@file"]
+                file_name = file_path.split("/")[-1]
+                diffuse_models_file_names_dict["gal_diffuse"] = file_name
+    return diffuse_models_file_names_dict
+
+
+def create_source_skymodel(source_info, dl3_aux_path, base_model_type="Fermi-XML", asgardpy_target_config=None):
+    """
+    Build SkyModels from given base model information.
+
+    If AsgardpyConfig section of the target is provided for the target
+    source information, it will be used to check if the target `source_name`
+    is provided in the base_model file. If it exists, then check if the model
+    information is to be read from AsgardpyConfig using `from_3d` boolean value.
+    Also, if EBL model information is provided in the AsgardpyConfig, it will
+    be added to the SkyModel object.
+
+    Parameters
+    ----------
+    source_info: dict
+        Dictionary containing the source models information from XML file.
+    dl3_aux_path: str
+        Path location of the DL3 auxiliary files for reading Spatial Models
+        from separate files.
+    base_model_type: str
+        Name indicating the model format used to read the skymodels from.
+    asgardpy_target_config: `AsgardpyConfig`
+        Config section containing the Target source information.
+
+    Returns
+    -------
+    source_sky_model: `gammapy.modeling.SkyModel`
+        SkyModels object for the given source information.
+    is_source_target: bool
+        Boolean to check if the Models belong to the target source.
+    """
+    if base_model_type == "Fermi-XML":
+        source_name = source_info["@name"]
+        spectrum_type = source_info["spectrum"]["@type"]
+        spectrum_params = source_info["spectrum"]["parameter"]
+
+        # initialized to check for the case if target spectral model information
+        # is to be taken from the Config
+        spectral_model = None
+
+        # Check if target_source file exists
+        is_source_target = False
+        ebl_atten = False
+
+        # If Target source model's spectral component is to be taken from Config
+        # and not from 3D dataset.
+        if asgardpy_target_config:
+            source_name_check = source_name.replace("_", "").replace(" ", "")
+            target_check = asgardpy_target_config.source_name.replace("_", "").replace(" ", "")
+
+            if source_name_check == target_check:
+                source_name = asgardpy_target_config.source_name
+                is_source_target = True
+
+                # Only taking the spectral model information right now.
+                if not asgardpy_target_config.from_3d:
+                    models_ = read_models_from_asgardpy_config(asgardpy_target_config)
+                    spectral_model = models_[0].spectral_model
+
+        if spectral_model is None:
+            # Define the Spectral Model type for Gammapy
+            spectral_model, ebl_atten = get_gammapy_spectral_model(
+                spectrum_type,
+                ebl_atten,
+                base_model_type,
+            )
+            spectrum_type = spectrum_type.split("EblAtten::")[-1]
+
+            # Read the parameter values from XML file to create SpectralModel
+            params_list = xml_spectral_model_to_gammapy(
+                spectrum_params,
+                spectrum_type,
+                is_target=is_source_target,
+                keep_sign=ebl_atten,
+                base_model_type=base_model_type,
+            )
+
+            for param_ in params_list:
+                setattr(spectral_model, param_.name, param_)
+
+            if asgardpy_target_config:
+                config_spectral = asgardpy_target_config.components[0].spectral
+                ebl_absorption_included = config_spectral.ebl_abs.reference != ""
+
+                if is_source_target and ebl_absorption_included:
+                    ebl_model = config_spectral.ebl_abs
+
+                    if ebl_model.filename.is_file():
+                        ebl_spectral_model = EBLAbsorptionNormSpectralModel.read(
+                            str(ebl_model.filename), redshift=ebl_model.redshift
+                        )
+                        ebl_model.reference = ebl_model.filename.name[:-8].replace("-", "_")
+                    else:
+                        ebl_spectral_model = EBLAbsorptionNormSpectralModel.read_builtin(
+                            ebl_model.reference, redshift=ebl_model.redshift
+                        )
+                    spectral_model = spectral_model * ebl_spectral_model
+
+        # Reading Spatial model from the XML file
+        spatial_model = xml_spatial_model_to_gammapy(dl3_aux_path, source_info["spatialModel"], base_model_type)
+
+        spatial_model.freeze()
+        source_sky_model = SkyModel(
+            spectral_model=spectral_model,
+            spatial_model=spatial_model,
+            name=source_name,
+        )
+
+    return source_sky_model, is_source_target
+
+
+def create_iso_diffuse_skymodel(iso_file, key_name):
+    """
+    Create a SkyModel of the Fermi Isotropic Diffuse Model and assigning
+    name as per the observation key. If there are no distinct key types of
+    files, the value is None.
+
+    Parameters
+    ----------
+    iso_file: str
+        Path to the isotropic diffuse model file
+    key: str
+        Instrument key-name, if exists
+
+    Returns
+    -------
+    diff_iso: `gammapy.modeling.SkyModel`
+        SkyModel object of the isotropic diffuse model.
+    """
+    diff_iso = create_fermi_isotropic_diffuse_model(filename=iso_file, interp_kwargs={"fill_value": None})
+
+    if key_name:
+        diff_iso._name = f"{diff_iso.name}-{key_name}"
+
+    # Parameters' limits
+    diff_iso.spectral_model.model1.parameters[0].min = 0.001
+    diff_iso.spectral_model.model1.parameters[0].max = 10
+    diff_iso.spectral_model.model2.parameters[0].min = 0
+    diff_iso.spectral_model.model2.parameters[0].max = 10
+
+    return diff_iso
+
+
+def create_gal_diffuse_skymodel(diff_gal_file):
+    """
+    Create SkyModel of the Diffuse Galactic sources either by reading a file or
+    by using a provided Map object.
+
+    Parameters
+    ----------
+    diff_gal_file: Path, `gammapy.maps.Map`
+        Path to the isotropic diffuse model file, or a Map object already read
+        from a file.
+
+    Returns
+    -------
+    model: `gammapy.modeling.SkyModel`
+        SkyModel object read from a given galactic diffuse model file.
+    diff_gal: `gammapy.maps.Map`
+        Map object of the galactic diffuse model
+    """
+    if not isinstance(diff_gal_file, Map):
+        # assuming it is Path or str type
+        diff_gal_filename = diff_gal_file
+        diff_gal = Map.read(diff_gal_file)
+        diff_gal.meta["filename"] = diff_gal_filename
+    else:
+        diff_gal = diff_gal_file
+
+    template_diffuse = SPATIAL_MODEL_REGISTRY.get_cls("TemplateSpatialModel")(
+        diff_gal, normalize=False, filename=diff_gal.meta["filename"]
+    )
+    model = SkyModel(
+        spectral_model=SPECTRAL_MODEL_REGISTRY.get_cls("PowerLawNormSpectralModel")(),
+        spatial_model=template_diffuse,
+        name="diffuse-iem",
+    )
+    model.parameters["norm"].min = 0
+    model.parameters["norm"].max = 10
+    model.parameters["norm"].frozen = False
+
+    return model, diff_gal

--- a/src/asgardpy/gammapy/tests/test_xml_model.py
+++ b/src/asgardpy/gammapy/tests/test_xml_model.py
@@ -1,40 +1,65 @@
-import logging
+from pathlib import Path
 
 import pytest
 from gammapy.modeling.models import Models
 
-from asgardpy.config import AsgardpyConfig
-from asgardpy.data.dataset_3d import Dataset3DGeneration
+from asgardpy.gammapy.read_models import read_fermi_xml_models_list
 
 
 @pytest.mark.test_data
-def test_xml(gammapy_data_path):
+def test_xml_only_source_models(gammapy_data_path):
     """Test reading various different Fermi-XML source models."""
+    from asgardpy.config import AsgardpyConfig
 
     config = AsgardpyConfig()
-    log = logging.getLogger("Test XML model")
+    list_source_models = []
 
-    dataset_3d = config.dataset3d.instruments[0]
-    dataset_3d.input_dl3[0].input_dir = f"{gammapy_data_path}fermipy-crab/"
-    aux_path = dataset_3d.input_dl3[0].input_dir
+    dl3_aux_path = Path(f"{gammapy_data_path}fermipy-crab/")
 
-    xml_file = aux_path / "test_fermi_xml_models.xml"
+    diffuse_models = {}
+
+    xml_file = dl3_aux_path / "test_fermi_xml_models.xml"
     config.target.source_name = "4FGL J0534.5+2201i"
     config.target.from_3d = True
 
-    data_3d = Dataset3DGeneration(log, dataset_3d, config)
-    data_3d.get_list_objects(aux_path, xml_file)
-    data_3d.list_sources = Models(data_3d.list_sources)
+    list_source_models, _ = read_fermi_xml_models_list(
+        list_source_models, dl3_aux_path, xml_file, diffuse_models, config.target
+    )
+    list_source_models = Models(list_source_models)
 
-    assert data_3d.list_sources[0].spatial_model.tag[0] == "GaussianSpatialModel"
-    assert data_3d.list_sources[0].spectral_model.tag[1] == "lp"
-    assert data_3d.list_sources[1].spatial_model.tag[0] == "TemplateSpatialModel"
-    assert data_3d.list_sources[2].spatial_model.tag[0] == "PointSpatialModel"
-    assert data_3d.list_sources[2].spectral_model.tag[1] == "ecpl"
-    assert data_3d.list_sources[3].spectral_model.tag[1] == "pl"
-    assert data_3d.list_sources[4].spectral_model.tag[1] == "ecpl"
-    assert data_3d.list_sources[5].spectral_model.tag[1] == "secpl-4fgl-dr3"
-    assert data_3d.list_sources[6].spectral_model.tag[1] == "bpl"
-    assert data_3d.list_sources[7].spectral_model.tag[1] == "sbpl"
-    assert data_3d.list_sources[8].spectral_model.tag[1] == "pl"
-    assert data_3d.list_sources[8].spatial_model.tag[0] == "GaussianSpatialModel"
+    assert list_source_models[0].spatial_model.tag[0] == "GaussianSpatialModel"
+    assert list_source_models[0].spectral_model.tag[1] == "lp"
+    assert list_source_models[1].spatial_model.tag[0] == "TemplateSpatialModel"
+    assert list_source_models[2].spatial_model.tag[0] == "PointSpatialModel"
+    assert list_source_models[2].spectral_model.tag[1] == "ecpl"
+    assert list_source_models[3].spectral_model.tag[1] == "pl"
+    assert list_source_models[4].spectral_model.tag[1] == "ecpl"
+    assert list_source_models[5].spectral_model.tag[1] == "secpl-4fgl-dr3"
+    assert list_source_models[6].spectral_model.tag[1] == "bpl"
+    assert list_source_models[7].spectral_model.tag[1] == "sbpl"
+    assert list_source_models[8].spectral_model.tag[1] == "pl"
+    assert list_source_models[8].spatial_model.tag[0] == "GaussianSpatialModel"
+
+
+@pytest.mark.test_data
+def test_xml_with_diffuse_models(gammapy_data_path):
+    """Test reading Fermi-XML models with diffuse models included."""
+
+    list_source_models = []
+    diffuse_models = {}
+
+    dl3_aux_path = Path(f"{gammapy_data_path}fermipy-crab/")
+
+    xml_file = dl3_aux_path / "srcmdl_00.xml"
+    diffuse_models["gal_diffuse"] = dl3_aux_path / "gll_iem_v07_cutout.fits"
+    diffuse_models["iso_diffuse"] = dl3_aux_path / "iso_P8R3_SOURCE_V3_FRONT_v1.txt"
+    diffuse_models["key_name"] = None
+
+    list_source_models, diffuse_models = read_fermi_xml_models_list(
+        list_source_models, dl3_aux_path, xml_file, diffuse_models
+    )
+    list_source_models = Models(list_source_models)
+
+    assert list_source_models[1].name == "4FGL J0534.5+2201s"
+    assert list_source_models[-1].name == "diffuse-iem"
+    assert list_source_models[-2].name == "fermi-diffuse-iso"

--- a/tox.ini
+++ b/tox.ini
@@ -51,9 +51,11 @@ deps =
 # update commands for all the dev tools
     black >= 22.10
     ruff
+    isort
 commands =
     black {posargs:src/asgardpy}
     ruff check {posargs:src/asgardpy}
+    isort {posargs:src/asgardpy}
 
 [testenv:type]
 description = run type checks


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #153 

Updated the main function to read such model files as `asgardpy.gammapy.read_models.read_fermi_xml_models_list` which is self-consistent and does not require `AsgardpyConfig` object or `asgardpy.data` module support. An example of this can be seen in a unit test in `asgardpy.gammapy` module and in the example `notebooks/test_models.ipynb`.

This PR also reduces the major load of reading and updating models in `asgardpy.data.dataset_3d.Dataset3DGeneration` class and in `asgardpy.data.target`.