### PR TITLE
Generalize reading and writing Gammapy Models

### DIFF
--- a/docs/changes/179.bugfix.rst
+++ b/docs/changes/179.bugfix.rst
@@ -1,1 +1,2 @@
 Generalize functions to read and write Gammapy model config files via AsgardpyConfig.
+Separate some of the functions responsible for operations in a distinct ``asgardpy.config.operations`` module.

--- a/docs/changes/179.bugfix.rst
+++ b/docs/changes/179.bugfix.rst
@@ -1,0 +1,1 @@
+Generalize functions to read and write Gammapy model config files via AsgardpyConfig.

--- a/docs/source/_api_docs/config/config.rst
+++ b/docs/source/_api_docs/config/config.rst
@@ -2,7 +2,7 @@ asgardpy.config.generator module
 ================================
 
 .. automodule:: asgardpy.config.generator
-   :members: AsgardpyConfig, GeneralConfig, get_model_template, recursive_merge_dicts
+   :members: AsgardpyConfig, GeneralConfig, get_model_template, recursive_merge_dicts, gammapy_model_to_asgardpy_model_config, write_asgardpy_model_to_file
    :undoc-members:
    :show-inheritance:
 

--- a/docs/source/_api_docs/config/generator.rst
+++ b/docs/source/_api_docs/config/generator.rst
@@ -2,7 +2,7 @@ asgardpy.config.generator module
 ================================
 
 .. automodule:: asgardpy.config.generator
-   :members: AsgardpyConfig, GeneralConfig, get_model_template, recursive_merge_dicts, gammapy_model_to_asgardpy_model_config, write_asgardpy_model_to_file
+   :members: AsgardpyConfig, GeneralConfig, gammapy_model_to_asgardpy_model_config, write_asgardpy_model_to_file
    :undoc-members:
    :show-inheritance:
 

--- a/docs/source/_api_docs/config/operations.rst
+++ b/docs/source/_api_docs/config/operations.rst
@@ -1,5 +1,5 @@
-asgardpy.config.generator module
-================================
+asgardpy.config.operations module
+=================================
 
 .. automodule:: asgardpy.config.operations
    :members: get_model_template, recursive_merge_dicts, deep_update

--- a/docs/source/_api_docs/config/operations.rst
+++ b/docs/source/_api_docs/config/operations.rst
@@ -1,0 +1,7 @@
+asgardpy.config.generator module
+================================
+
+.. automodule:: asgardpy.config.operations
+   :members: get_model_template, recursive_merge_dicts, deep_update
+   :undoc-members:
+   :show-inheritance:

--- a/scripts/check_preferred_model.py
+++ b/scripts/check_preferred_model.py
@@ -5,14 +5,13 @@ from pathlib import Path
 import numpy as np
 
 from asgardpy.analysis import AsgardpyAnalysis
-from asgardpy.config import AsgardpyConfig
+from asgardpy.config import AsgardpyConfig, write_asgardpy_model_to_file
 from asgardpy.stats import (
     check_model_preference_aic,
     copy_target_config,
     fetch_all_analysis_fit_info,
     get_model_config_files,
     tabulate_best_fit_stats,
-    write_output_config_yaml,
 )
 
 log = logging.getLogger(__name__)
@@ -155,8 +154,9 @@ def main():
 
             path = config_path.parent / f"{config_path_file_name}_model_most_pref_{name}.yaml"
 
-            yaml_ = write_output_config_yaml(main_analysis_list[tag]["Analysis"].final_model[0])
-            path.write_text(yaml_)
+            write_asgardpy_model_to_file(
+                gammapy_model=main_analysis_list[tag]["Analysis"].final_model[0], output_file=path
+            )
 
 
 if __name__ == "__main__":

--- a/src/asgardpy/analysis/analysis.py
+++ b/src/asgardpy/analysis/analysis.py
@@ -9,7 +9,10 @@ from gammapy.modeling.models import CompoundSpectralModel, Models, SkyModel
 from pydantic import ValidationError
 
 from asgardpy.analysis.step import AnalysisStep
-from asgardpy.config.generator import AsgardpyConfig, gammapy_to_asgardpy_model_config
+from asgardpy.config.generator import (
+    AsgardpyConfig,
+    gammapy_model_to_asgardpy_model_config,
+)
 from asgardpy.data.target import set_models
 from asgardpy.stats.stats import get_goodness_of_fit_stats
 
@@ -48,7 +51,7 @@ class AsgardpyAnalysis:
                 other_config = AsgardpyConfig.read(self.config.target.models_file)
                 self.config = self.config.update(other_config)
             except ValidationError:
-                self.config = gammapy_to_asgardpy_model_config(
+                self.config = gammapy_model_to_asgardpy_model_config(
                     gammapy_model=self.config.target.models_file,
                     asgardpy_config_file=self.config,
                 )

--- a/src/asgardpy/analysis/analysis.py
+++ b/src/asgardpy/analysis/analysis.py
@@ -9,10 +9,7 @@ from gammapy.modeling.models import CompoundSpectralModel, Models, SkyModel
 from pydantic import ValidationError
 
 from asgardpy.analysis.step import AnalysisStep
-from asgardpy.config.generator import (
-    AsgardpyConfig,
-    gammapy_model_to_asgardpy_model_config,
-)
+from asgardpy.config import AsgardpyConfig, gammapy_model_to_asgardpy_model_config
 from asgardpy.data.target import set_models
 from asgardpy.stats.stats import get_goodness_of_fit_stats
 

--- a/src/asgardpy/analysis/tests/test_analysis_steps.py
+++ b/src/asgardpy/analysis/tests/test_analysis_steps.py
@@ -58,6 +58,7 @@ def test_analysis_basics(gammapy_data_path, base_config):
 @pytest.mark.test_data
 def test_ebl_deabsorbed(gammapy_data_path, ebl_hess_pks):
     """Testing generation of EBL-deabsorbed Flux points."""
+    from asgardpy.config.generator import write_asgardpy_model_to_file
 
     analysis = AsgardpyAnalysis(ebl_hess_pks)
 
@@ -67,3 +68,8 @@ def test_ebl_deabsorbed(gammapy_data_path, ebl_hess_pks):
 
     assert len(analysis.model_deabs.parameters) == 3
     assert analysis.flux_points_deabs
+
+    write_asgardpy_model_to_file(
+        gammapy_model=analysis.final_model,
+        output_file=None,
+    )

--- a/src/asgardpy/config/__init__.py
+++ b/src/asgardpy/config/__init__.py
@@ -5,15 +5,21 @@ Configuration Module
 from asgardpy.config.generator import (
     AsgardpyConfig,
     GeneralConfig,
-    all_model_templates,
     gammapy_model_to_asgardpy_model_config,
+    write_asgardpy_model_to_file,
+)
+from asgardpy.config.operations import (
+    all_model_templates,
+    compound_model_dict_converstion,
+    deep_update,
     get_model_template,
     recursive_merge_dicts,
-    write_asgardpy_model_to_file,
 )
 
 __all__ = [
     "all_model_templates",
+    "compound_model_dict_converstion",
+    "deep_update",
     "AsgardpyConfig",
     "GeneralConfig",
     "gammapy_model_to_asgardpy_model_config",

--- a/src/asgardpy/config/__init__.py
+++ b/src/asgardpy/config/__init__.py
@@ -6,16 +6,18 @@ from asgardpy.config.generator import (
     AsgardpyConfig,
     GeneralConfig,
     all_model_templates,
-    gammapy_to_asgardpy_model_config,
+    gammapy_model_to_asgardpy_model_config,
     get_model_template,
     recursive_merge_dicts,
+    write_asgardpy_model_to_file,
 )
 
 __all__ = [
     "all_model_templates",
     "AsgardpyConfig",
     "GeneralConfig",
-    "gammapy_to_asgardpy_model_config",
+    "gammapy_model_to_asgardpy_model_config",
     "get_model_template",
     "recursive_merge_dicts",
+    "write_asgardpy_model_to_file",
 ]

--- a/src/asgardpy/config/generator.py
+++ b/src/asgardpy/config/generator.py
@@ -250,7 +250,6 @@ def write_asgardpy_model_to_file(gammapy_model, output_file=None, recursive_merg
     temp_ = asgardpy_config.model_dump(exclude_defaults=True)
     temp_["target"].pop("models_file", None)
     temp_["target"]["components"][0]["spectral"].pop("ebl_abs", None)
-    # temp_["target"]["components"][0].pop("name", None) # Extra?
 
     yaml_ = yaml.dump(
         temp_,

--- a/src/asgardpy/config/generator.py
+++ b/src/asgardpy/config/generator.py
@@ -240,10 +240,10 @@ def write_asgardpy_model_to_file(gammapy_model, output_file=None, recursive_merg
         if not isinstance(output_file, Path):
             output_file = Path(os.path.expandvars(output_file))
 
-    temp_ = asgardpy_config.model_dump(exclude_defaults=True)["target"]
-    temp_.pop("models_file", None)
-    temp_["components"][0]["spectral"].pop("ebl_abs", None)
-    temp_["components"][0].pop("name", None)
+    temp_ = asgardpy_config.model_dump(exclude_defaults=True)
+    temp_["target"].pop("models_file", None)
+    temp_["target"]["components"][0]["spectral"].pop("ebl_abs", None)
+    temp_["target"]["components"][0].pop("name", None)
 
     yaml_ = yaml.dump(
         temp_,

--- a/src/asgardpy/config/generator.py
+++ b/src/asgardpy/config/generator.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import yaml
-from gammapy.modeling.models import CompoundSpectralModel, Models
+from gammapy.modeling.models import CompoundSpectralModel, Models, SkyModel
 from gammapy.utils.scripts import make_path, read_yaml
 
 from asgardpy.analysis.step_base import AnalysisStepEnum
@@ -180,11 +180,11 @@ def gammapy_model_to_asgardpy_model_config(gammapy_model, asgardpy_config_file=N
 
     if isinstance(gammapy_model, Models):
         models_gpy = gammapy_model
-    elif isinstance(gammapy_model, str | Path):
-        models_gpy = Models.read(gammapy_model)
+    elif isinstance(gammapy_model, SkyModel):
+        models_gpy = Models(gammapy_model)
     else:
         try:
-            models_gpy = Models(gammapy_model)
+            models_gpy = Models.read(gammapy_model)
         except KeyError:
             log.error("%s File cannot be read by Gammapy Models", gammapy_model)
             return None
@@ -250,7 +250,7 @@ def write_asgardpy_model_to_file(gammapy_model, output_file=None, recursive_merg
     temp_ = asgardpy_config.model_dump(exclude_defaults=True)
     temp_["target"].pop("models_file", None)
     temp_["target"]["components"][0]["spectral"].pop("ebl_abs", None)
-    temp_["target"]["components"][0].pop("name", None)
+    # temp_["target"]["components"][0].pop("name", None) # Extra?
 
     yaml_ = yaml.dump(
         temp_,

--- a/src/asgardpy/config/model_templates/model_template_ecpl-3fgl.yaml
+++ b/src/asgardpy/config/model_templates/model_template_ecpl-3fgl.yaml
@@ -1,8 +1,9 @@
-components:
--   spectral:
-        type: ExpCutoffPowerLaw3FGLSpectralModel
-        parameters:
-        - {name: index, value: 1.5}
-        - {name: amplitude, value: 1.0e-12, unit: TeV-1 s-1 cm-2}
-        - {name: reference, unit: TeV}
-        - {name: ecut, value: 10.0, unit: TeV}
+target:
+    components:
+    -   spectral:
+            type: ExpCutoffPowerLaw3FGLSpectralModel
+            parameters:
+            - {name: index, value: 1.5}
+            - {name: amplitude, value: 1.0e-12, unit: TeV-1 s-1 cm-2}
+            - {name: reference, unit: TeV}
+            - {name: ecut, value: 10.0, unit: TeV}

--- a/src/asgardpy/config/model_templates/model_template_ecpl-3fgl.yaml
+++ b/src/asgardpy/config/model_templates/model_template_ecpl-3fgl.yaml
@@ -1,0 +1,8 @@
+components:
+-   spectral:
+        type: ExpCutoffPowerLaw3FGLSpectralModel
+        parameters:
+        - {name: index, value: 1.5}
+        - {name: amplitude, value: 1.0e-12, unit: TeV-1 s-1 cm-2}
+        - {name: reference, unit: TeV}
+        - {name: ecut, value: 10.0, unit: TeV}

--- a/src/asgardpy/config/model_templates/model_template_pl_ebl.yaml
+++ b/src/asgardpy/config/model_templates/model_template_pl_ebl.yaml
@@ -1,0 +1,12 @@
+target:
+    components:
+    -   spectral:
+            type: PowerLawSpectralModel
+            parameters:
+            - {name: index, value: 2.5549376641853416, error: 0.2982383919410344,
+                min: 0.5, max: 5.0}
+            - {name: amplitude, value: 1.2975797753986047e-11, unit: TeV-1 s-1 cm-2,
+                error: 1.9471254047998817e-12, min: 1.0e-13, max: 0.01}
+            - {name: reference, unit: TeV, min: 0.0001, max: 100.0}
+            ebl_abs: {filename: /home/chaitanya/software/gammapy-datasets/1.2/ebl/ebl_dominguez11.fits.gz,
+                redshift: 0.11599999999999999}

--- a/src/asgardpy/config/operations.py
+++ b/src/asgardpy/config/operations.py
@@ -1,0 +1,154 @@
+"""
+Main AsgardpyConfig Operations Module
+"""
+
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+
+import numpy as np
+from gammapy.modeling.models import Models, SkyModel
+
+__all__ = [
+    "all_model_templates",
+    "compound_model_dict_converstion",
+    "get_model_template",
+    "recursive_merge_dicts",
+    "deep_update",
+]
+
+CONFIG_PATH = Path(__file__).resolve().parent
+
+log = logging.getLogger(__name__)
+
+
+def all_model_templates():
+    """
+    Collect all Template Models provided in Asgardpy, and their small tag names.
+    """
+    template_files = sorted(list(CONFIG_PATH.glob("model_templates/model_template*yaml")))
+
+    all_tags = []
+    for file in template_files:
+        all_tags.append(file.name.split("_")[-1].split(".")[0])
+    all_tags = np.array(all_tags)
+
+    return all_tags, template_files
+
+
+def get_model_template(spec_model_tag):
+    """
+    Read a particular template model yaml filename to create an AsgardpyConfig
+    object.
+    """
+    all_tags, template_files = all_model_templates()
+    new_model_file = None
+
+    for file, tag in zip(template_files, all_tags, strict=True):
+        if spec_model_tag == tag:
+            new_model_file = file
+    return new_model_file
+
+
+def check_gammapy_model(gammapy_model):
+    """
+    For a given object type, try to read it as a Gammapy Models object.
+    """
+    if isinstance(gammapy_model, Models | SkyModel):
+        models_gpy = Models(gammapy_model)
+    else:
+        try:
+            models_gpy = Models.read(gammapy_model)
+        except KeyError:
+            raise TypeError("%s File cannot be read by Gammapy Models", gammapy_model) from KeyError
+
+    return models_gpy
+
+
+def recursive_merge_dicts(base_config, extra_config):
+    """
+    recursively merge two dictionaries.
+    Entries in extra_config override entries in base_config. The built-in
+    update function cannot be used for hierarchical dicts.
+
+    Also for the case when there is a list of dicts involved, one has to be
+    more careful. The extra_config may have longer list of dicts as compared
+    with the base_config, in which case, the extra items are simply added to
+    the merged final list.
+
+    Combined here are 2 options from SO.
+
+    See:
+    http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth/3233356#3233356
+    and also
+    https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth/18394648#18394648
+
+    Parameters
+    ----------
+    base_config : dict
+        dictionary to be merged
+    extra_config : dict
+        dictionary to be merged
+    Returns
+    -------
+    final_config : dict
+        merged dict
+    """
+    final_config = base_config.copy()
+
+    for key, value in extra_config.items():
+        if key in final_config and isinstance(final_config[key], list):
+            new_config = []
+
+            for key_, value_ in zip(final_config[key], value, strict=False):
+                key_ = recursive_merge_dicts(key_ or {}, value_)
+                new_config.append(key_)
+
+            # For example moving from a smaller list of model parameters to a
+            # longer list.
+            if len(final_config[key]) < len(extra_config[key]):
+                for value_ in value[len(final_config[key]) :]:
+                    new_config.append(value_)
+            final_config[key] = new_config
+
+        elif key in final_config and isinstance(final_config[key], dict):
+            final_config[key] = recursive_merge_dicts(final_config.get(key) or {}, value)
+        else:
+            final_config[key] = value
+
+    return final_config
+
+
+def deep_update(d, u):
+    """
+    Recursively update a nested dictionary.
+
+    Just like in Gammapy, taken from: https://stackoverflow.com/a/3233356/19802442
+    """
+    for k, v in u.items():
+        if isinstance(v, Mapping):
+            d[k] = deep_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+def compound_model_dict_converstion(dict):
+    """
+    Given a Gammapy CompoundSpectralModel as a dict object, convert it into
+    an Asgardpy form.
+    """
+    ebl_abs = dict["model2"]
+    ebl_abs["alpha_norm"] = ebl_abs["parameters"][0]["value"]
+    ebl_abs["redshift"] = ebl_abs["parameters"][1]["value"]
+    ebl_abs.pop("parameters", None)
+
+    dict["type"] = dict["model1"]["type"]
+    dict["parameters"] = dict["model1"]["parameters"]
+    dict["ebl_abs"] = ebl_abs
+
+    dict.pop("model1", None)
+    dict.pop("model2", None)
+    dict.pop("operator", None)
+
+    return dict

--- a/src/asgardpy/config/tests/test_config.py
+++ b/src/asgardpy/config/tests/test_config.py
@@ -83,25 +83,25 @@ def test_config_update_gammapy(gammapy_data_path, base_config_1d):
 
     import os
 
-    from asgardpy.config.generator import gammapy_to_asgardpy_model_config
+    from asgardpy.config.generator import gammapy_model_to_asgardpy_model_config
 
     main_config = AsgardpyConfig()
 
     other_config_path = f"{gammapy_data_path}fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
     other_config_path_2 = f"{gammapy_data_path}estimators/pks2155_hess_lc/models.yaml"
 
-    other_config_1 = gammapy_to_asgardpy_model_config(
+    other_config_1 = gammapy_model_to_asgardpy_model_config(
         other_config_path,
         recursive_merge=False,
     )
-    other_config_2 = gammapy_to_asgardpy_model_config(
+    other_config_2 = gammapy_model_to_asgardpy_model_config(
         other_config_path,
         base_config_1d,
         recursive_merge=False,
     )
 
     main_config.write("test_base_config.yaml", overwrite=True)
-    other_config_3 = gammapy_to_asgardpy_model_config(
+    other_config_3 = gammapy_model_to_asgardpy_model_config(
         other_config_path_2,
         "test_base_config.yaml",
         recursive_merge=False,
@@ -158,3 +158,29 @@ def test_config_update():
         main_config.update(5)
     assert new_spectral_model_name_2 == "SmoothBrokenPowerLawSpectralModel"
     assert len(spectral_model_params) == 6
+
+
+def test_write_model_config():
+    """From a Gammapy Models object, write it as an AsgardpyConfig file."""
+
+    from gammapy.modeling.models import (
+        ExpCutoffPowerLaw3FGLSpectralModel,
+        Models,
+        SkyModel,
+    )
+
+    from asgardpy.analysis import AsgardpyAnalysis
+    from asgardpy.config import (
+        AsgardpyConfig,
+        get_model_template,
+        write_asgardpy_model_to_file,
+    )
+
+    config_ = AsgardpyConfig()
+    analysis_ = AsgardpyAnalysis(config_)
+    model_ = SkyModel(name="Template", spectral_model=ExpCutoffPowerLaw3FGLSpectralModel())
+    analysis_.final_model = Models(model_)
+
+    write_asgardpy_model_to_file(analysis_.final_model)
+
+    assert get_model_template("ecpl-3fgl")

--- a/src/asgardpy/config/tests/test_config.py
+++ b/src/asgardpy/config/tests/test_config.py
@@ -192,3 +192,8 @@ def test_write_model_config():
 
     with pytest.raises(TypeError):
         write_asgardpy_model_to_file()
+
+    write_asgardpy_model_to_file(
+        gammapy_model=model_,
+        output_file=None,
+    )

--- a/src/asgardpy/config/tests/test_config.py
+++ b/src/asgardpy/config/tests/test_config.py
@@ -170,7 +170,8 @@ def test_write_model_config():
     )
 
     from asgardpy.analysis import AsgardpyAnalysis
-    from asgardpy.config import (
+    from asgardpy.config.generator import (
+        CONFIG_PATH,
         AsgardpyConfig,
         get_model_template,
         write_asgardpy_model_to_file,
@@ -179,8 +180,15 @@ def test_write_model_config():
     config_ = AsgardpyConfig()
     analysis_ = AsgardpyAnalysis(config_)
     model_ = SkyModel(name="Template", spectral_model=ExpCutoffPowerLaw3FGLSpectralModel())
+
     analysis_.final_model = Models(model_)
 
-    write_asgardpy_model_to_file(analysis_.final_model)
-
     assert get_model_template("ecpl-3fgl")
+
+    write_asgardpy_model_to_file(
+        gammapy_model=model_,
+        output_file=str(CONFIG_PATH) + "/model_templates/model_template_ecpl-3fgl.yaml",
+    )
+
+    with pytest.raises(TypeError):
+        write_asgardpy_model_to_file("None")

--- a/src/asgardpy/config/tests/test_config.py
+++ b/src/asgardpy/config/tests/test_config.py
@@ -56,7 +56,7 @@ def test_config_time():
 def test_get_model_template():
     """Test for reading a model template by a given tag."""
 
-    from asgardpy.config.generator import get_model_template
+    from asgardpy.config.operations import get_model_template
 
     new_model = get_model_template("eclp")
 
@@ -128,7 +128,7 @@ def test_config_update_gammapy(gammapy_data_path, base_config_1d):
 def test_config_update():
     """Tests to update target model config from other AsgardpyConfig file."""
 
-    from asgardpy.config.generator import get_model_template
+    from asgardpy.config.operations import get_model_template
 
     main_config = AsgardpyConfig()
 
@@ -170,12 +170,8 @@ def test_write_model_config():
     )
 
     from asgardpy.analysis import AsgardpyAnalysis
-    from asgardpy.config.generator import (
-        CONFIG_PATH,
-        AsgardpyConfig,
-        get_model_template,
-        write_asgardpy_model_to_file,
-    )
+    from asgardpy.config.generator import AsgardpyConfig, write_asgardpy_model_to_file
+    from asgardpy.config.operations import CONFIG_PATH, get_model_template
 
     config_ = AsgardpyConfig()
     analysis_ = AsgardpyAnalysis(config_)

--- a/src/asgardpy/config/tests/test_config.py
+++ b/src/asgardpy/config/tests/test_config.py
@@ -191,4 +191,4 @@ def test_write_model_config():
     )
 
     with pytest.raises(TypeError):
-        write_asgardpy_model_to_file("None")
+        write_asgardpy_model_to_file()

--- a/src/asgardpy/conftest.py
+++ b/src/asgardpy/conftest.py
@@ -110,7 +110,7 @@ def base_config_1d(base_config):
 def gpy_mwl_config(mwl_config_path, gammapy_data_path):
     """Define the Gammapy MWL Tutorial config."""
 
-    from asgardpy.config import AsgardpyConfig, gammapy_to_asgardpy_model_config
+    from asgardpy.config import AsgardpyConfig, gammapy_model_to_asgardpy_model_config
 
     config = AsgardpyConfig().read(mwl_config_path)
 
@@ -123,7 +123,7 @@ def gpy_mwl_config(mwl_config_path, gammapy_data_path):
         0
     ].dl4_dataset_info.dl4_dataset.input_dir = f"{gammapy_data_path}joint-crab/spectra/hess/"
 
-    other_config = gammapy_to_asgardpy_model_config(config.target.models_file, recursive_merge=False)
+    other_config = gammapy_model_to_asgardpy_model_config(config.target.models_file, recursive_merge=False)
 
     config = config.update(other_config)
 

--- a/src/asgardpy/data/tests/test_target.py
+++ b/src/asgardpy/data/tests/test_target.py
@@ -4,7 +4,7 @@ import pytest
 def test_models_from_config():
     """Test reading models from asgardpy config."""
 
-    from asgardpy.config.generator import AsgardpyConfig, get_model_template
+    from asgardpy.config import AsgardpyConfig, get_model_template
     from asgardpy.data.target import read_models_from_asgardpy_config, set_models
 
     config_eclp = AsgardpyConfig.read(get_model_template("eclp"))

--- a/src/asgardpy/stats/__init__.py
+++ b/src/asgardpy/stats/__init__.py
@@ -18,7 +18,6 @@ from asgardpy.stats.utils import (
     get_model_config_files,
     tabulate_best_fit_stats,
     copy_target_config,
-    write_output_config_yaml,
 )
 
 __all__ = [
@@ -32,5 +31,4 @@ __all__ = [
     "get_model_config_files",
     "tabulate_best_fit_stats",
     "copy_target_config",
-    "write_output_config_yaml",
 ]

--- a/src/asgardpy/stats/tests/test_model_pref.py
+++ b/src/asgardpy/stats/tests/test_model_pref.py
@@ -17,7 +17,6 @@ def test_preferred_model(base_config_1d):
         fetch_all_analysis_fit_info,
         get_model_config_files,
         tabulate_best_fit_stats,
-        write_output_config_yaml,
     )
 
     select_model_tags = ["lp", "bpl2", "ecpl", "pl", "eclp"]
@@ -70,9 +69,6 @@ def test_preferred_model(base_config_1d):
     assert lrt_best_model == "lp"
     assert aic_best_model == "lp"
     assert len(stats_table.colnames) == 11
-
-    tag = spec_models_list[fit_success_list][0]
-    write_output_config_yaml(main_analysis_list[tag]["Analysis"].final_model[0])
 
     # Check for bad comparisons, same dof
     p_val_0, g_sig_0, dof_0 = check_model_preference_lrt(4.4, 2.2, 2, 2)

--- a/src/asgardpy/stats/tests/test_pivot_energy.py
+++ b/src/asgardpy/stats/tests/test_pivot_energy.py
@@ -25,7 +25,7 @@ def test_get_pivot_energy_from_start(gpy_hess_magic):
     the AsgardpyAnalysis object. Test using the SpectralModel of ECPL
     and without any associated EBL absorption model.
     """
-    from asgardpy.config.generator import get_model_template
+    from asgardpy.config.operations import get_model_template
 
     new_model = get_model_template("ecpl2")
     gpy_hess_magic.target.models_file = new_model

--- a/src/asgardpy/stats/utils.py
+++ b/src/asgardpy/stats/utils.py
@@ -3,10 +3,9 @@ Module containing additional utility functions for selecting a preferred model.
 """
 
 import numpy as np
-import yaml
 from astropy.table import QTable
 
-from asgardpy.config.generator import AsgardpyConfig, all_model_templates
+from asgardpy.config.generator import all_model_templates
 from asgardpy.stats.stats import check_model_preference_lrt
 
 __all__ = [
@@ -14,7 +13,6 @@ __all__ = [
     "get_model_config_files",
     "tabulate_best_fit_stats",
     "copy_target_config",
-    "write_output_config_yaml",
 ]
 
 
@@ -166,28 +164,3 @@ def tabulate_best_fit_stats(spec_models_list, fit_success_list, main_analysis_li
     stats_table = QTable(fit_stats_table)
 
     return stats_table
-
-
-def write_output_config_yaml(model_):
-    """With the selected spectral model, update a default config in yaml."""
-
-    spec_model = model_.spectral_model.model1.to_dict()
-
-    temp_config = AsgardpyConfig()
-    temp_config.target.components[0] = spec_model
-
-    # Update with the spectral model info
-    temp_ = temp_config.dict(exclude_defaults=True)
-
-    # Remove some of the unnecessary keys
-    temp_["target"].pop("models_file", None)
-    temp_["target"]["components"][0]["spectral"].pop("ebl_abs", None)
-
-    yaml_ = yaml.dump(
-        temp_,
-        sort_keys=False,
-        indent=4,
-        width=80,
-        default_flow_style=None,
-    )
-    return yaml_

--- a/src/asgardpy/stats/utils.py
+++ b/src/asgardpy/stats/utils.py
@@ -5,7 +5,7 @@ Module containing additional utility functions for selecting a preferred model.
 import numpy as np
 from astropy.table import QTable
 
-from asgardpy.config.generator import all_model_templates
+from asgardpy.config.operations import all_model_templates
 from asgardpy.stats.stats import check_model_preference_lrt
 
 __all__ = [


### PR DESCRIPTION
Have a common function to write back model parameters stored in `AsgardpyConfig.target.components` into a file, similar to the available `model_templates`.