### PR TITLE
Fix issues with dependencies

### DIFF
--- a/docs/changes/182.maintenance.rst
+++ b/docs/changes/182.maintenance.rst
@@ -1,0 +1,1 @@
+Fixing Sphinx build issue caused by the upgrade from [`#181 <https://github.com/chaimain/asgardpy/pull/181>`__] by pinning Towncrier.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "tox",
   "tqdm",
   "pydantic>=2.5",
-  "towncrier",
+  "towncrier<24.7",
 ]
 
 [project.urls]
@@ -77,7 +77,7 @@ dev = [
   "pytest-cov",
   "build",
   "setuptools_scm",
-  "Sphinx>=6.0,<9",
+  "Sphinx>=8.0",
   "furo>=2022.12.7",
   "myst-parser>=2.0",
   "sphinx-copybutton>=0.5.0",


### PR DESCRIPTION
Pinning Towncrier until [Issue 92](https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92) is resolved. Fixes build issue caused after #181 