### PR TITLE
Remove redundant changelog updating tool

### DIFF
--- a/docs/changes/194.bugfix.rst
+++ b/docs/changes/194.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes Issue [`#193 <https://github.com/chaimain/asgardpy/issues/193>`_] and resolves problem of the changelog as introduced in PR [`#191 <https://github.com/chaimain/asgardpy/pull/191>`_].

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,8 +4,6 @@
 Changelog
 =========
 
-.. towncrier-draft-entries:: |release| [UNRELEASED DRAFT]
-
 .. towncrier release notes start
 
 .. changelog::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,6 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx.ext.inheritance_diagram",
     "sphinxcontrib.autodoc_pydantic",
-    "sphinxcontrib.towncrier.ext",
     "sphinx_changelog",
 ]
 

--- a/environment.yml
+++ b/environment.yml
@@ -57,7 +57,6 @@ dependencies:
   - sphinx-autobuild>=2021.3.14
   - sphinx-autodoc-typehints
   - sphinx_changelog
-  - sphinxcontrib-towncrier
   - packaging
   - pip:
       - pytest-sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev = [
   "sphinx-copybutton>=0.5.0",
   "sphinx-autobuild>=2021.3.14",
   "sphinx-autodoc-typehints",
-  "sphinxcontrib-towncrier",
   "sphinx_changelog",
   "autodoc_pydantic>=2.1",
   "packaging",


### PR DESCRIPTION
<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #193 and resolves problems introduced with #191 
